### PR TITLE
Minor enhancement: place calendar widget under cursor.

### DIFF
--- a/src/System/Taffybar/SimpleClock.hs
+++ b/src/System/Taffybar/SimpleClock.hs
@@ -38,7 +38,13 @@ toggleCalendar w c = liftIO $ do
       let topLevelWindow = castToWindow topLevel
       windowSetTransientFor c topLevelWindow
 
+      windowSetPosition c WinPosMouse
+      (x,  y) <- windowGetPosition c
+      (_, y') <- widgetGetSize w
       widgetShowAll c
+      if y > y'
+          then windowMove c x (y - y')
+          else windowMove c x y'
 
   return True
 


### PR DESCRIPTION
It used to appear at coordinates (0,0) on my monitor while I use to keep the clock on the far right - this was somewhat annoying.
