### PR TITLE
Bugfix: prevent calendar popup from being destoyed.

### DIFF
--- a/src/System/Taffybar/SimpleClock.hs
+++ b/src/System/Taffybar/SimpleClock.hs
@@ -21,6 +21,10 @@ makeCalendar = do
   container <- windowNew
   cal <- calendarNew
   containerAdd container cal
+  -- prevent calendar from being destroyed, it can be only hidden:
+  _ <- on container deleteEvent $ do
+    liftIO (widgetHideAll container)
+    return True
   return container
 
 toggleCalendar w c = liftIO $ do


### PR DESCRIPTION
The window should intercept the delete event and hide itself,
otherwise it's gone forever.
