### PR TITLE
add verticalBarSetColors

### DIFF
--- a/src/System/Taffybar/Widgets/VerticalBar.hs
+++ b/src/System/Taffybar/Widgets/VerticalBar.hs
@@ -8,6 +8,7 @@ module System.Taffybar.Widgets.VerticalBar (
   -- * Accessors/Constructors
   verticalBarNew,
   verticalBarSetPercent,
+  verticalBarSetColors,
   defaultBarConfig
   ) where
 
@@ -44,6 +45,18 @@ defaultBarConfig c = BarConfig { barBorderColor = (0.5, 0.5, 0.5)
                                , barWidth = 15
                                , barDirection = VERTICAL
                                }
+
+verticalBarSetColors :: VerticalBarHandle
+                     -> (Double -> (Double, Double, Double))
+                     -> (Double, Double, Double)
+                     -> IO ()
+verticalBarSetColors (VBH mv) color bgColor = do
+  s <- readMVar mv
+  let bc = (barConfig s) {barColor = color, barBackgroundColor = bgColor}
+  modifyMVar_ mv (\s' -> return s' {barConfig = bc})
+  case barIsBootstrapped s of
+    False -> return ()
+    True -> postGUIAsync $ widgetQueueDraw $ barCanvas s
 
 verticalBarSetPercent :: VerticalBarHandle -> Double -> IO ()
 verticalBarSetPercent (VBH mv) pct = do


### PR DESCRIPTION
{sorry for the duplicate, i pull-requested master instead of the feature branch}

updates the barColor and barBackgroundColor in the BarConfig of a VeticalBar.
repaints the bar if it its bootstrapped, or just update cfg for next time

useful for a volume bar that turns red on mute.

i also use it to depict values greater than 1.0. i change the color {from, say, green-on-black to blue-on-green} and subtract 1 from the value {and so on until the value is <= 1.0}.
this makes sense in the context of volume, for indicating amplification without wasting space.

i would greatly appreciate if you merged it, but barring that, could you instead simply export the barstate field accessors?
