### PR TITLE
Fixes support for utf8 layout names (bug #54)

### DIFF
--- a/src/System/Taffybar/Hooks/PagerHints.hs
+++ b/src/System/Taffybar/Hooks/PagerHints.hs
@@ -38,7 +38,6 @@ module System.Taffybar.Hooks.PagerHints (
 
 import Codec.Binary.UTF8.String (encode)
 import Control.Monad
-import Data.Char (ord)
 import Data.Monoid
 import Foreign.C.Types (CInt)
 import XMonad
@@ -82,7 +81,7 @@ setCurrentLayout l = withDisplay $ \dpy -> do
   r <- asks theRoot
   a <- xLayoutProp
   c <- getAtom "UTF8_STRING"
-  let l' = map (fromIntegral . ord) l
+  let l' = map fromIntegral (encode l)
   io $ changeProperty8 dpy r a c propModeReplace l'
 
 -- | Set the value of the \"Visible Workspaces\" hint to the one given.


### PR DESCRIPTION
This makes it so that utf8 layout names can be displayed on the taffybar and fixes bug #54 
