### PR TITLE
allow circumenventing dyre

### DIFF
--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -121,7 +121,8 @@ module System.Taffybar (
   TaffybarConfig(..),
   defaultTaffybar,
   defaultTaffybarConfig,
-  Position(..)
+  Position(..),
+  taffybarMain
   ) where
 
 import qualified Config.Dyre as Dyre


### PR DESCRIPTION
I like to keep taffybar + xmonad in a cabal sandbox and update binaries manually -- this means no .config/taffybar/taffybar.hs either.

Possible by exposing the real main.
