### PR TITLE
Added textual cpu monitor (System.Taffybar.TextCPUMonitor)

### DIFF
--- a/src/System/Taffybar/TextCPUMonitor.hs
+++ b/src/System/Taffybar/TextCPUMonitor.hs
@@ -1,0 +1,27 @@
+module System.Taffybar.TextCPUMonitor(textCpuMonitorNew) where
+
+import Text.Printf
+import Text.StringTemplate
+import System.Information.CPU
+import System.Taffybar.Widgets.PollingLabel
+import Graphics.UI.Gtk
+
+-- | Creates a simple textual CPU monitor. It updates once every polling
+-- period (in seconds).
+textCpuMonitorNew :: String -- ^ Format. You can use variables: $total$, $user$, $system$
+                  -> Double -- ^ Polling period (in seconds)
+                  -> IO Widget
+textCpuMonitorNew fmt period = do
+        label <- pollingLabelNew fmt period callback
+        widgetShowAll label
+        return label
+        where
+            callback = do
+                (userLoad, systemLoad, totalLoad) <- cpuLoad
+                let [userLoad', systemLoad', totalLoad'] = map (((printf "%.2f") :: Double -> String).(*100)) [userLoad, systemLoad, totalLoad]
+                let template = newSTMP fmt
+                let template' = setManyAttrib [ ("user", userLoad'),
+                                              ("system", systemLoad'),
+                                              ("total", totalLoad') ] template
+                return $ render template'
+

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -91,6 +91,7 @@ library
                    System.Taffybar.MPRIS2,
                    System.Taffybar.Battery,
                    System.Taffybar.CPUMonitor,
+                   System.Taffybar.TextCPUMonitor,
                    System.Taffybar.DiskIOMonitor,
                    System.Taffybar.FSMonitor,
                    System.Taffybar.LayoutSwitcher,


### PR DESCRIPTION
Hello, I think graph monitors can't show cpu usage as accurately as textual monitor. So I written simple textual monitor for my usage and I want to share it with your project.
