### PR TITLE
Make NetMonitor widget honor interface state

### DIFF
--- a/src/System/Information/Network.hs
+++ b/src/System/Information/Network.hs
@@ -14,7 +14,9 @@
 --
 -----------------------------------------------------------------------------
 
-module System.Information.Network (getNetInfo) where
+module System.Information.Network ( getNetInfo
+                                  , isUpNet
+                                  ) where
 
 import System.Information.StreamInfo (getParsedInfo)
 
@@ -30,3 +32,10 @@ parse = map tuplize . map words . drop 2 . lines
 tuplize :: [String] -> (String, [Integer])
 tuplize s = (init $ head s, map read [s!!1, s!!out])
     where out = (length s) - 8
+
+-- | Returns whether the given network interface is up, according to
+-- the contents of the @\/sys\/class\/net\/'interface'\/operstate@
+-- file.
+isUpNet :: String -> IO Bool
+isUpNet interface = do state <- readFile $ "/sys/class/net/" ++ interface ++ "/operstate"
+                       return $ head state == 'u'

--- a/src/System/Taffybar/NetMonitor.hs
+++ b/src/System/Taffybar/NetMonitor.hs
@@ -18,7 +18,7 @@ module System.Taffybar.NetMonitor (netMonitorNew) where
 
 import Data.IORef
 import Graphics.UI.Gtk
-import System.Information.Network (getNetInfo)
+import System.Information.Network (getNetInfo, isUpNet)
 import System.Taffybar.Widgets.PollingLabel
 import Text.Printf (printf)
 
@@ -36,9 +36,12 @@ netMonitorNew interval interface = do
 
 showInfo :: IORef [Integer] -> Double -> String -> IO String
 showInfo sample interval interface = do
-    thisSample <- getNetInfo interface
-    lastSample <- readIORef sample
-    writeIORef sample thisSample
-    let deltas = map fromIntegral $ zipWith (-) thisSample lastSample
-        [incoming, outgoing] = map (/(interval*1e3)) deltas
-    return $ printf "▼ %.2fkb/s ▲ %.2fkb/s" incoming outgoing
+    isUp <- isUpNet interface
+    if isUp
+       then do thisSample <- getNetInfo interface
+               lastSample <- readIORef sample
+               writeIORef sample thisSample
+               let deltas = map fromIntegral $ zipWith (-) thisSample lastSample
+                   [incoming, outgoing] = map (/(interval*1e3)) deltas
+               return $ printf "▼ %.2fkb/s ▲ %.2fkb/s" incoming outgoing
+       else return ""


### PR DESCRIPTION
Hi,

I have been using this in my taffybar for some time, and it works
well. I have widgets for wlan0, eth0, usb0, and I only need to display
the one which is currently up. This commit makes NetMonitor display
the speed information only if the interface is up. Would you consider
merging this?
