### PR TITLE
parse /proc/meminfo using labels instead of line indices

### DIFF
--- a/src/System/Information/Memory.hs
+++ b/src/System/Information/Memory.hs
@@ -3,32 +3,38 @@ module System.Information.Memory (
   parseMeminfo
   ) where
 
-toMB :: [String] -> Double
-toMB line = (read $ line !! 1 :: Double) / 1024
+toMB :: String -> Double
+toMB size = (read size :: Double) / 1024
 
-data MemoryInfo = MemoryInfo { memoryUsedRatio :: Double
-                             , memoryTotal :: Double
+data MemoryInfo = MemoryInfo { memoryTotal :: Double
                              , memoryFree :: Double
                              , memoryBuffer :: Double
                              , memoryCache :: Double
-                             , memoryRest :: Double
-                             , memoryUsed :: Double
+                             , memoryRest :: Double      -- free + buffer + cache
+                             , memoryUsed :: Double      -- total - rest
+                             , memoryUsedRatio :: Double -- used / total
                              }
+emptyMemoryInfo = MemoryInfo 0 0 0 0 0 0 0
+
+parseLines (line:lines) memInfo = parseLines lines newMemInfo
+  where (label:size:_) = words line
+        newMemInfo = case label of
+                       "MemTotal:" -> memInfo { memoryTotal = toMB size }
+                       "MemFree:"  -> memInfo { memoryFree = toMB size }
+                       "Buffers:"  -> memInfo { memoryBuffer = toMB size }
+                       "Cached:"   -> memInfo { memoryCache = toMB size }
+                       _           -> memInfo
+parseLines _ memInfo = memInfo
 
 parseMeminfo :: IO MemoryInfo
 parseMeminfo = do
   s <- readFile "/proc/meminfo"
-  let content = map words $ take 4 $ lines s
-      [total, free, buffer, cache ] = map toMB content
-      rest = free + buffer + cache
-      used = total - rest
-      usedRatio = used / total
-  return MemoryInfo { memoryUsedRatio = usedRatio
-                    , memoryTotal = total
-                    , memoryFree = free
-                    , memoryBuffer = buffer
-                    , memoryCache = cache
-                    , memoryRest = rest
-                    , memoryUsed = used
-                    }
+  let m = parseLines (lines s) emptyMemoryInfo
+      rest = memoryFree m + memoryBuffer m + memoryCache m
+      used = memoryTotal m - rest
+      usedRatio = used / memoryTotal m
+  return m { memoryRest = rest
+           , memoryUsed = used
+           , memoryUsedRatio = usedRatio
+           }
 


### PR DESCRIPTION
fixes issue #75
i dont know how portable hard-coding the labels is, but its definitely more portable than hardcoding the indices.
