### PR TITLE
Bugfix: catch ALL exceptions in notify

### DIFF
--- a/src/System/Taffybar/Pager.hs
+++ b/src/System/Taffybar/Pager.hs
@@ -106,7 +106,7 @@ notify :: Event -> (Listener, Filter) -> IO ()
 notify event (listener, eventFilter) =
   case event of
     PropertyEvent _ _ _ _ _ atom _ _ ->
-      when (atom == eventFilter) $ E.catch (listener event) ignoreIOException
+      when (atom == eventFilter) $ E.catch (listener event) ignoreException
     _ -> return ()
 
 -- | Registers the given Listener as a subscriber of events of the given
@@ -119,8 +119,8 @@ subscribe pager listener filterName = do
   let next = (listener, eventFilter)
   writeIORef (clients pager) (next : registered)
 
-ignoreIOException :: IOException -> IO ()
-ignoreIOException _ = return ()
+ignoreException :: SomeException -> IO ()
+ignoreException _ = return ()
 
 -- | Creates markup with the given foreground and background colors and the
 -- given contents.


### PR DESCRIPTION
Very occasionally (once/twice in a month, using taffybar daily) I've observed the desktop switcher freeze, meaning that it won't update graphically, though I can still click on the buttons to switch to a different desktop. I suspect that this may be caused by some exception that is _not_ of type IOException being thrown during event notification. This is an attempt to prevent this from happening by catching a more general type of exceptions (SomeException).
