### PR TITLE
Use enclosed-exceptions to catch all notification errors

### DIFF
--- a/src/System/Taffybar/Pager.hs
+++ b/src/System/Taffybar/Pager.hs
@@ -41,7 +41,8 @@ module System.Taffybar.Pager
   ) where
 
 import Control.Concurrent (forkIO)
-import Control.Exception as E
+import Control.Exception
+import Control.Exception.Enclosed (catchAny)
 import Control.Monad.Reader
 import Data.IORef
 import Graphics.UI.Gtk (Markup, escapeMarkup)
@@ -106,7 +107,7 @@ notify :: Event -> (Listener, Filter) -> IO ()
 notify event (listener, eventFilter) =
   case event of
     PropertyEvent _ _ _ _ _ atom _ _ ->
-      when (atom == eventFilter) $ E.catch (listener event) ignoreIOException
+      when (atom == eventFilter) $ catchAny (listener event) ignoreException
     _ -> return ()
 
 -- | Registers the given Listener as a subscriber of events of the given
@@ -119,8 +120,8 @@ subscribe pager listener filterName = do
   let next = (listener, eventFilter)
   writeIORef (clients pager) (next : registered)
 
-ignoreIOException :: IOException -> IO ()
-ignoreIOException _ = return ()
+ignoreException :: SomeException -> IO ()
+ignoreException _ = return ()
 
 -- | Creates markup with the given foreground and background colors and the
 -- given contents.

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -99,7 +99,8 @@ library
                  X11 >= 1.5.0.1,
                  safe >= 0.3 && < 1,
                  split >= 0.1.4.2,
-                 process >= 1.0.1.1
+                 process >= 1.0.1.1,
+                 enclosed-exceptions >= 1.0.0.1
   hs-source-dirs: src
   pkgconfig-depends: gtk+-2.0
   exposed-modules: System.Taffybar,


### PR DESCRIPTION
This _should_ make the desktop switcher resilient against all kinds of exceptions, both synchronous and asynchronous.
