### PR TITLE
Network widget: rollover counters

### DIFF
--- a/src/System/Taffybar/NetMonitor.hs
+++ b/src/System/Taffybar/NetMonitor.hs
@@ -64,7 +64,7 @@ showInfo sample interval interface template prec = do
       Just thisSample -> do
         lastSample <- readIORef sample
         writeIORef sample thisSample
-        let deltas = map fromIntegral $ zipWith (-) thisSample lastSample
+        let deltas = map (max 0 . fromIntegral) $ zipWith (-) thisSample lastSample
             speed@[incomingb, outgoingb] = map (/(interval)) deltas
             [incomingkb, outgoingkb] = map (setDigits prec . (/1024)) speed
             [incomingmb, outgoingmb] = map (setDigits prec . (/square 1024)) speed


### PR DESCRIPTION
The \`bytes' from /proc/net/dev get reset to 0 when the counter goes over 2^32. In which case the netMonitor widget (calculating deltas from last and current sample) shows **negative** values. I think it's ok to show `0` values instead.