### PR TITLE
Add support for scrolling on WorkspaceSwitcher

### DIFF
--- a/src/System/Information/EWMHDesktopInfo.hs
+++ b/src/System/Information/EWMHDesktopInfo.hs
@@ -29,6 +29,7 @@ module System.Information.EWMHDesktopInfo
   , getVisibleWorkspaces
   , getWorkspaceNames
   , switchToWorkspace
+  , switchOneWorkspace
   , getWindowTitle
   , getWindowClass
   , getActiveWindowTitle
@@ -80,6 +81,24 @@ switchToWorkspace :: WorkspaceIdx -> X11Property ()
 switchToWorkspace (WSIdx idx) = do
   cmd <- getAtom "_NET_CURRENT_DESKTOP"
   sendCommandEvent cmd (fromIntegral idx)
+
+-- | Move one workspace up or down from the current workspace
+switchOneWorkspace :: Bool -> Int -> X11Property ()
+switchOneWorkspace dir end = do
+  cur <- getCurrentWorkspace
+  switchToWorkspace $ if dir then getPrev cur end else getNext cur end
+
+-- | Check for corner case and switch one workspace up
+getPrev :: WorkspaceIdx -> Int -> WorkspaceIdx
+getPrev (WSIdx idx) end
+  | idx > 0 = WSIdx $ idx-1
+  | otherwise = WSIdx end
+
+-- | Check for corner case and switch one workspace down
+getNext :: WorkspaceIdx -> Int -> WorkspaceIdx
+getNext (WSIdx idx) end
+  | idx < end = WSIdx $ idx+1
+  | otherwise = WSIdx 0
 
 -- | Get the title of the given X11 window.
 getWindowTitle :: X11Window -> X11Property String

--- a/src/System/Taffybar/WorkspaceSwitcher.hs
+++ b/src/System/Taffybar/WorkspaceSwitcher.hs
@@ -211,6 +211,13 @@ addButton hbox desktop idx
     Gtk.widgetSetName ebox $ name ws
     Gtk.eventBoxSetVisibleWindow ebox False
     _ <- Gtk.on ebox Gtk.buttonPressEvent $ switch idx
+    _ <- Gtk.on ebox Gtk.scrollEvent $ do
+      dir <- Gtk.eventScrollDirection
+      case dir of
+        Gtk.ScrollUp    -> switchOne True (length desktop - 1)
+        Gtk.ScrollLeft  -> switchOne True (length desktop - 1)
+        Gtk.ScrollDown  -> switchOne False (length desktop - 1)
+        Gtk.ScrollRight -> switchOne False (length desktop - 1)
     Gtk.containerAdd ebox lbl
     Gtk.boxPackStart hbox ebox Gtk.PackNatural 0
   | otherwise = return ()
@@ -252,6 +259,12 @@ mark desktop decorate wsIdx
 switch :: (MonadIO m) => WorkspaceIdx -> m Bool
 switch idx = do
   liftIO $ withDefaultCtx (switchToWorkspace idx)
+  return True
+
+-- | Switch to one workspace up or down given a boolean direction and the last workspace
+switchOne :: (MonadIO m) => Bool -> Int -> m Bool
+switchOne dir end = do
+  liftIO $ withDefaultCtx (if dir then switchOneWorkspace dir end else switchOneWorkspace dir end)
   return True
 
 -- | Modify the Desktop inside the given IORef, so that the Workspace at the


### PR DESCRIPTION
Scrolling with mouse/touchpad on WorkspaceSwitcher allows moving one workspace up or down.