### PR TITLE
Fix some issues with taffybar.rc loading

### DIFF
--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -261,15 +261,14 @@ setTaffybarSize cfg window = do
 
 taffybarMain :: TaffybarConfig -> IO ()
 taffybarMain cfg = do
-  -- Override the default GTK theme path settings.  This causes the
-  -- bar (by design) to ignore the real GTK theme and just use the
-  -- provided minimal theme to set the background and text colors.
-  -- Users can override this default.
-  defaultGtkConfig <- getDefaultConfigFile "taffybar.rc"
-  userGtkConfig <- getUserConfigFile "taffybar" "taffybar.rc"
-  rcSetDefaultFiles [ defaultGtkConfig, userGtkConfig ]
 
   _ <- initGUI
+
+  -- Load default and user gtk resources
+  defaultGtkConfig <- getDefaultConfigFile "taffybar.rc"
+  userGtkConfig <- getUserConfigFile "taffybar" "taffybar.rc"
+  rcParse defaultGtkConfig
+  rcParse userGtkConfig
 
   Just disp <- displayGetDefault
   nscreens <- displayGetNScreens disp

--- a/taffybar.rc
+++ b/taffybar.rc
@@ -1,6 +1,10 @@
-gtk_color_scheme = "black:#000000\nwhite:#FFFFFF\ngreen:#00FF00\nred:#FF0000"
 
-style "default" {
+style "taffybar-default" {
+  color["black"] = "#000000"
+  color["white"] = "#ffffff"
+  color["green"] = "#00ff00"
+  color["red"]   = "#ff0000"
+
   bg[NORMAL]   = @black
   fg[NORMAL]   = @white
   text[NORMAL] = @white
@@ -8,15 +12,15 @@ style "default" {
   bg[PRELIGHT] = @black
 }
 
-style "active-window" = "default" {
+style "taffybar-active-window" = "taffybar-default" {
   fg[NORMAL] = @green
 }
 
-style "notification-button" = "default" {
+style "taffybar-notification-button" = "taffybar-default" {
   text[NORMAL] = @red
   fg[NORMAL]   = @red
 }
 
-widget "Taffybar*" style "default"
-widget "Taffybar*WindowSwitcher*label" style "active-window"
-widget "*NotificationCloseButton" style "notification-button"
+widget "Taffybar*" style "taffybar-default"
+widget "Taffybar*WindowSwitcher*label" style "taffybar-active-window"
+widget "*NotificationCloseButton" style "taffybar-notification-button"


### PR DESCRIPTION
This pull request fixes some issues with loading of taffybar.rc, mostly that it is now loaded after initGUI so it can override (and use) any resources loaded by the system gtkrc files, it also fixes an issue with using gtk_color_scheme, which causes already loaded rc files to be reloaded, which could cause overwriting of resources defined in taffybar.rc. It also prefixes all stylesdefined in taffybar.rc with the "taffybar-" so the style names should be more unique.