### PR TITLE
Multiple batteries support

### DIFF
--- a/src/System/Taffybar/Battery.hs
+++ b/src/System/Taffybar/Battery.hs
@@ -4,12 +4,14 @@
 -- service.
 --
 -- Currently it reports only the first battery it finds.  If it does
--- not find a batterym it just returns an obnoxious widget with
+-- not find a battery, it just returns an obnoxious widget with
 -- warning text in it.  Battery hotplugging is not supported.  These
 -- more advanced features could be supported if there is interest.
 module System.Taffybar.Battery (
   batteryBarNew,
+  batteryBarsNew,
   textBatteryNew,
+  textBatteriesNew,
   defaultBatteryConfig
   ) where
 
@@ -25,44 +27,83 @@ import System.Information.Battery
 import System.Taffybar.Widgets.PollingBar
 import System.Taffybar.Widgets.PollingLabel
 
+
+-- | Just the battery info that will be used for display (this makes combining several easier).
+data BatteryWidgetInfo = BWI {seconds :: Maybe Int64, percent :: Int } deriving (Eq, Show)
+
+-- | Combination operation for 'BatteryWidgetInfo'.
+-- If one battery lacks time information, combination has no time information
+(<>) :: BatteryWidgetInfo -> BatteryWidgetInfo -> BatteryWidgetInfo
+b1 <> b2 =
+  BWI { seconds = (+) <$> seconds b1 <*> seconds b2
+      , percent = (percent b1 + percent b2) `div` 2}
+
+-- | Format a duration expressed as seconds to hours and minutes
+formatDuration :: Maybe Int64 -> String
+formatDuration Nothing = ""
+formatDuration (Just secs) = let minutes = secs `div` 60
+                                 hours = minutes `div` 60
+                                 minutes' = minutes `mod` 60
+                             in printf "%02d:%02d" hours minutes'
+
 safeGetBatteryInfo :: IORef BatteryContext -> IO (Maybe BatteryInfo)
 safeGetBatteryInfo mv = do
   ctxt <- readIORef mv
   E.catchAny (getBatteryInfo ctxt) $ \_ -> reconnect
   where
     reconnect = do
+      IO.hPutStrLn IO.stderr "reconnecting"
       mctxt <- batteryContextNew
       case mctxt of
         Nothing -> IO.hPutStrLn IO.stderr "Could not reconnect to UPower"
         Just ctxt -> writeIORef mv ctxt
       return Nothing
 
-battInfo :: IORef BatteryContext -> String -> IO String
-battInfo r fmt = do
+getBatteryWidgetInfo :: IORef BatteryContext -> IO (Maybe BatteryWidgetInfo)
+getBatteryWidgetInfo r = do
   minfo <- safeGetBatteryInfo r
   case minfo of
-    Nothing -> return ""
+    Nothing -> return Nothing
     Just info -> do
       let battPctNum :: Int
           battPctNum = floor (batteryPercentage info)
-          formatTime :: Int64 -> String
-          formatTime seconds =
-            let minutes = seconds `div` 60
-                hours = minutes `div` 60
-                minutes' = minutes `mod` 60
-            in printf "%02d:%02d" hours minutes'
-
-          battTime :: String
+          battTime :: Maybe Int64
           battTime = case (batteryState info) of
-            BatteryStateCharging -> (formatTime $ batteryTimeToFull info)
-            BatteryStateDischarging -> (formatTime $ batteryTimeToEmpty info)
-            _ -> "-"
+            BatteryStateCharging -> Just $ batteryTimeToFull info
+            BatteryStateDischarging -> Just $ batteryTimeToEmpty info
+            _ -> Nothing
+      return . Just $ BWI {seconds = battTime, percent = battPctNum}
 
-          tpl = newSTMP fmt
-          tpl' = setManyAttrib [ ("percentage", show battPctNum)
-                               , ("time", battTime)
-                               ] tpl
-      return $ render tpl'
+
+-- | Given (maybe summarized) battery info and format: provides the string to display
+formatBattInfo :: Maybe BatteryWidgetInfo -> String -> String
+formatBattInfo Nothing _       =  ""
+formatBattInfo (Just info) fmt =
+  let tpl = newSTMP fmt
+      tpl' = setManyAttrib [ ("percentage", (show . percent) info)
+                           , ("time", formatDuration (seconds info))
+                           ] tpl
+  in render tpl'
+
+-- | Provides textual information regarding a single battery
+battInfo :: IORef BatteryContext -> String -> IO String
+battInfo r fmt = do
+  mwinfo <- getBatteryWidgetInfo r
+  return $ formatBattInfo mwinfo fmt
+
+-- | Provides textual information regarding multiple batteries
+battSumm :: [IORef BatteryContext] -> String -> IO String
+battSumm rs fmt = do
+  winfos <- sequence $ fmap getBatteryWidgetInfo rs
+  let ws :: [BatteryWidgetInfo]
+      ws = flatten winfos
+      flatten [] = []
+      flatten ((Just a):as) = a:(flatten as)
+      flatten (Nothing:as)  = flatten as
+      combined = case ws of
+        [] -> Nothing
+        (a:as) -> Just $ foldr (<>) a as
+  return $ formatBattInfo combined fmt
 
 -- | A simple textual battery widget that auto-updates once every
 -- polling period (specified in seconds).  The displayed format is
@@ -84,6 +125,29 @@ textBatteryNew fmt pollSeconds = do
       l <- pollingLabelNew "" pollSeconds (battInfo r fmt)
       widgetShowAll l
       return l
+
+-- | A simple textual battery widget that auto-updates once every
+-- polling period (specified in seconds).  The displayed format is
+-- specified format string where $percentage$ is replaced with the
+-- percentage of battery remaining and $time$ is replaced with the
+-- time until the battery is fully charged/discharged.
+--
+-- Multiple battery values are combined as follows:
+-- - for time remaining, the largest value is used.
+-- - for percentage, the mean is taken.
+textBatteriesNew :: [IORef BatteryContext]
+                    -> String -- ^ Display format
+                    -> Double -- ^ Poll period in seconds
+                    -> IO Widget
+textBatteriesNew [] _ _ =
+  let lbl :: Maybe String
+      lbl = Just "No battery"
+  in labelNew lbl >>= return . toWidget
+textBatteriesNew rs fmt pollSeconds = do
+    l <- pollingLabelNew "" pollSeconds (battSumm rs fmt)
+    widgetShowAll l
+    return l
+
 
 -- | Returns the current battery percent as a double in the range [0,
 -- 1]
@@ -132,6 +196,28 @@ batteryBarNew battCfg pollSeconds = do
       r <- newIORef ctxt
       bar <- pollingBarNew battCfg pollSeconds (battPct r)
       boxPackStart b bar PackNatural 0
+      boxPackStart b txt PackNatural 0
+      widgetShowAll b
+      return (toWidget b)
+
+-- | Fancy graphical battery widgets that represent the current charge
+-- as colored vertical bars (one per battery).  There is also a
+-- textual percentage reppadout next to the bars, containing a summary of
+-- battery information.
+batteryBarsNew :: BarConfig -> Double -> IO Widget
+batteryBarsNew battCfg pollSeconds = do
+  battCtxt <- batteryContextsNew
+  case battCtxt of
+    [] -> do
+      let lbl :: Maybe String
+          lbl = Just "No battery"
+      toWidget <$> labelNew lbl
+    cs -> do
+      b <- hBoxNew False 1
+      rs <- sequence $ fmap newIORef cs
+      txt <- textBatteriesNew rs "$percentage$%" pollSeconds
+      bars <- sequence $ fmap (\r -> pollingBarNew battCfg pollSeconds (battPct r)) rs
+      sequence $ fmap (\bar -> boxPackStart b bar PackNatural 0) bars
       boxPackStart b txt PackNatural 0
       widgetShowAll b
       return (toWidget b)

--- a/src/System/Taffybar/Battery.hs
+++ b/src/System/Taffybar/Battery.hs
@@ -8,8 +8,8 @@
 -- warning text in it.  Battery hotplugging is not supported.  These
 -- more advanced features could be supported if there is interest.
 module System.Taffybar.Battery (
-  batteryBarsNew,
-  textBatteriesNew,
+  batteryBarNew,
+  textBatteryNew,
   defaultBatteryConfig
   ) where
 
@@ -109,15 +109,15 @@ battSumm rs fmt = do
 -- Multiple battery values are combined as follows:
 -- - for time remaining, the largest value is used.
 -- - for percentage, the mean is taken.
-textBatteriesNew :: [IORef BatteryContext]
+textBatteryNew :: [IORef BatteryContext]
                     -> String -- ^ Display format
                     -> Double -- ^ Poll period in seconds
                     -> IO Widget
-textBatteriesNew [] _ _ =
+textBatteryNew [] _ _ =
   let lbl :: Maybe String
       lbl = Just "No battery"
   in labelNew lbl >>= return . toWidget
-textBatteriesNew rs fmt pollSeconds = do
+textBatteryNew rs fmt pollSeconds = do
     l <- pollingLabelNew "" pollSeconds (battSumm rs fmt)
     widgetShowAll l
     return l
@@ -150,8 +150,8 @@ defaultBatteryConfig =
 -- as colored vertical bars (one per battery).  There is also a
 -- textual percentage reppadout next to the bars, containing a summary of
 -- battery information.
-batteryBarsNew :: BarConfig -> Double -> IO Widget
-batteryBarsNew battCfg pollSeconds = do
+batteryBarNew :: BarConfig -> Double -> IO Widget
+batteryBarNew battCfg pollSeconds = do
   battCtxt <- batteryContextsNew
   case battCtxt of
     [] -> do
@@ -161,7 +161,7 @@ batteryBarsNew battCfg pollSeconds = do
     cs -> do
       b <- hBoxNew False 1
       rs <- sequence $ fmap newIORef cs
-      txt <- textBatteriesNew rs "$percentage$%" pollSeconds
+      txt <- textBatteryNew rs "$percentage$%" pollSeconds
       let ris :: [(IORef BatteryContext, Int)]
           ris = rs `zip` [0..]
       bars <- sequence $ fmap (\(i, r) -> pollingBarNew battCfg pollSeconds (battPct i r)) ris


### PR DESCRIPTION
This changes the battery widget to support multiple batteries. It will display a bar for each battery and a single summarised text description.

- Overall percentage is just the mean, a useful improvement would be to weight it based on individual battery capacity but I get the impression that might not be something we can rely on for all batteries

- Overall time remaining is the sum, if all batteries provide this information. Only one of my two batteries does so I'm not sure if this is the right behaviour generally speaking, but I just use percentage anyway. I would guess this is right for discharging, when one is discharged at a time, and wrong for charging when both are charged simultaneously, maybe someone with two good batteries can confirm. 

Despite these shortcomings I find it useful for my two battery machine.

The first three commits add the new behaviour. I verified the new functions will work for a single battery so the fourth commit removes old functions. Fifth commit renames new functions to match old so that config will still work -- I can drop either or both of these if you want to preserve the old single-battery functions too but I think they're redundant.