### PR TITLE
Check names rather than length of workspaces

### DIFF
--- a/src/System/Taffybar/WorkspaceSwitcher.hs
+++ b/src/System/Taffybar/WorkspaceSwitcher.hs
@@ -124,7 +124,7 @@ updateDesktop :: Pager -> MV.MVar Desktop -> IO Bool
 updateDesktop pager deskRef = do
   wsnames <- withDefaultCtx getWorkspaceNames
   MV.modifyMVar deskRef $ \desktop ->
-    case length wsnames /= length desktop of
+    case map snd wsnames /= map name desktop of
       True -> do
         desk' <- getDesktop pager
         return (desk', True)
@@ -284,4 +284,3 @@ toggleUrgent deskRef (WSIdx idx) isUrgent =
                  _ : rest -> return $ ys ++ (ws' : rest)
                  _ -> return (ys ++ [ws'])
       _ -> return desktop
-


### PR DESCRIPTION
It is possible to rename workspaces using `DynamicWorkspaces`; in this case the list of names changes, without its length changing, and taffybar does not reflect the change. Sometimes this makes taffybar fall over as well, although not always.