### PR TITLE
Tweak NOAA URL in Weather module

### DIFF
--- a/src/System/Taffybar/Weather.hs
+++ b/src/System/Taffybar/Weather.hs
@@ -249,7 +249,7 @@ getCurrentWeather getter tpl formatter = do
 
 -- | The NOAA URL to get data from
 baseUrl :: String
-baseUrl = "http://weather.noaa.gov/pub/data/observations/metar/decoded"
+baseUrl = "http://tgftp.nws.noaa.gov/data/observations/metar/decoded"
 
 -- | A wrapper to allow users to specify a custom weather formatter.
 -- The default interpolates variables into a string as described


### PR DESCRIPTION
NOAA decommissioned the weather.noaa.gov website[0].  The same data are
still currently available from tgftp, so fetch from there.

Closes: #160

[0] http://www.nws.noaa.gov/os/notification/pns16-05decommissioning_web.htm