### PR TITLE
workspace images (_NET_WM_ICON and custom files)

### DIFF
--- a/src/System/Information/EWMHDesktopInfo.hs
+++ b/src/System/Information/EWMHDesktopInfo.hs
@@ -23,6 +23,7 @@ module System.Information.EWMHDesktopInfo
   ( X11Window      -- re-exported from X11DesktopInfo
   , X11WindowHandle
   , WorkspaceIdx(..)
+  , EWMHIcon(..)
   , withDefaultCtx -- re-exported from X11DesktopInfo
   , isWindowUrgent -- re-exported from X11DesktopInfo
   , getCurrentWorkspace
@@ -32,6 +33,7 @@ module System.Information.EWMHDesktopInfo
   , switchOneWorkspace
   , getWindowTitle
   , getWindowClass
+  , getWindowIcons
   , getActiveWindowTitle
   , getWindows
   , getWindowHandles
@@ -51,6 +53,8 @@ type X11WindowHandle = ((WorkspaceIdx, String, String), X11Window)
 
 newtype WorkspaceIdx = WSIdx Int
                      deriving (Show, Read, Ord, Eq)
+
+data EWMHIcon = EWMHIcon {width :: Int, height :: Int, pixelsARGB :: [Int]} deriving Show
 
 noFocus :: String
 noFocus = "..."
@@ -112,6 +116,24 @@ getWindowTitle window = do
 -- | Get the class of the given X11 window.
 getWindowClass :: X11Window -> X11Property String
 getWindowClass window = readAsString (Just window) "WM_CLASS"
+
+-- | Get list of icon ARGB data from EWMH
+getWindowIcons :: X11Window -> X11Property [EWMHIcon]
+getWindowIcons window = do
+  ints <- readAsListOfInt (Just window) "_NET_WM_ICON"
+  return $ parseIcons ints
+
+-- | Split icon raw integer data into EWMHIcons.
+-- Each icon raw data is an integer for width,
+--   followed by height,
+--   followed by exactly (width*height) ARGB pixels,
+--   optionally followed by the next icon.
+parseIcons :: [Int] -> [EWMHIcon]
+parseIcons (w:h:xs) | w>0 && h>0 && length pixels==w*h = icon : parseIcons rest
+  where pixels = take (w*h) xs
+        rest = drop (w*h) xs
+        icon = EWMHIcon {width = w, height = h, pixelsARGB = pixels}
+parseIcons _ = []
 
 withActiveWindow :: (X11Window -> X11Property String) -> X11Property String
 withActiveWindow getProp = do

--- a/src/System/Information/X11DesktopInfo.hs
+++ b/src/System/Information/X11DesktopInfo.hs
@@ -24,6 +24,7 @@ module System.Information.X11DesktopInfo
   , X11Window
   , withDefaultCtx
   , readAsInt
+  , readAsListOfInt
   , readAsString
   , readAsListOfString
   , readAsListOfWindow
@@ -68,6 +69,18 @@ readAsInt window name = do
   case prop of
     Just (x:_) -> return (fromIntegral x)
     _          -> return (-1)
+
+-- | Retrieve the property of the given window (or the root window,
+-- if Nothing) with the given name as a list of Ints. If that
+-- property hasn't been set, then return an empty list.
+readAsListOfInt :: Maybe X11Window -- ^ window to read from. Nothing means the root window.
+                -> String          -- ^ name of the property to retrieve
+                -> X11Property [Int]
+readAsListOfInt window name = do
+  prop <- fetch getWindowProperty32 window name
+  case prop of
+    Just xs -> return (map fromIntegral xs)
+    _       -> return []
 
 -- | Retrieve the property of the given window (or the root window,
 -- if Nothing) with the given name as a String. If the property

--- a/src/System/Taffybar/Pager.hs
+++ b/src/System/Taffybar/Pager.hs
@@ -67,6 +67,12 @@ data PagerConfig = PagerConfig
   , visibleWorkspace :: String -> String -- ^ all other visible workspaces (Xinerama or XRandR).
   , urgentWorkspace  :: String -> String -- ^ workspaces containing windows with the urgency hint set.
   , widgetSep        :: String           -- ^ separator to use between desktop widgets in 'TaffyPager'.
+  , useImages        :: Bool             -- ^ use images in the workspace switcher
+  , imageSize        :: Int              -- ^ image height and width in pixels
+  , fillEmptyImages  :: Bool             -- ^ fill empty images instead of clearing them
+  , preferCustomIcon :: Bool             -- ^ use custom icons over EWHMIcons
+  , customIcon       :: String -> String -- ^ get icon based on window title and class
+                     -> Maybe FilePath
   }
 
 -- | Structure containing the state of the Pager.
@@ -86,6 +92,11 @@ defaultPagerConfig   = PagerConfig
   , visibleWorkspace = wrap "(" ")" . escape
   , urgentWorkspace  = colorize "red" "yellow" . escape
   , widgetSep        = " : "
+  , useImages        = False
+  , imageSize        = 16
+  , fillEmptyImages  = False
+  , preferCustomIcon = False
+  , customIcon       = \_ _ -> Nothing
   }
 
 -- | Creates a new Pager component (wrapped in the IO Monad) that can be

--- a/src/System/Taffybar/WorkspaceSwitcher.hs
+++ b/src/System/Taffybar/WorkspaceSwitcher.hs
@@ -30,8 +30,9 @@ import Control.Applicative
 import qualified Control.Concurrent.MVar as MV
 import Control.Monad
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.List ((\\), findIndices, sortOn)
+import Data.List ((\\), findIndices, sortBy)
 import Data.Maybe (listToMaybe)
+import Data.Ord (comparing)
 import Data.Word (Word8)
 import Foreign.C.Types (CUChar(..))
 import Foreign.Marshal.Array (newArray)
@@ -292,6 +293,7 @@ selectEWMHIcon imgSize (Just (_, _, icons)) = listToMaybe prefIcon
         smallestLargerIcon = take 1 $ dropWhile ((<=imgSize).height) sortedIcons
         largestIcon = take 1 $ reverse sortedIcons
         prefIcon = smallestLargerIcon ++ largestIcon
+        sortOn f = sortBy (comparing f)
 selectEWMHIcon _ _ = Nothing
 
 -- | Select a file using customIcon config.


### PR DESCRIPTION
- disabled by default, non-breaking change
- parses EWMH hint _NET_WM_ICON to work out-of-the-box with most modern programs
- allows parsing custom icon files based on the window title and class
  (user can implement a lookup for their desktop environment)

`default config (no images)`
![20161126_ss1](https://cloud.githubusercontent.com/assets/592062/20645687/9355eec6-b433-11e6-98c3-06295e731ffc.png)

`with images enabled`
![20161126_ss2](https://cloud.githubusercontent.com/assets/592062/20645688/93563386-b433-11e6-9414-94bd56796bfe.png)

`larger icons, custom image loader for terminal-with-VIM-open`
![20161126_ss3](https://cloud.githubusercontent.com/assets/592062/20645686/9355aa7e-b433-11e6-84c3-8479819c34d6.png)

`my config (uses additional GTK code)`
![20161126_ss4](https://cloud.githubusercontent.com/assets/592062/20645685/935597a0-b433-11e6-8c9c-7b40311511df.png)