### PR TITLE
workspace styling (workspaceGap, workspacePad, workspaceBorder)

### DIFF
--- a/src/System/Taffybar/Pager.hs
+++ b/src/System/Taffybar/Pager.hs
@@ -68,6 +68,7 @@ data PagerConfig = PagerConfig
   , urgentWorkspace  :: String -> String -- ^ workspaces containing windows with the urgency hint set.
   , widgetSep        :: String           -- ^ separator to use between desktop widgets in 'TaffyPager'.
   , workspaceGap     :: Int              -- ^ space in pixels between workspace buttons
+  , workspacePad     :: Bool             -- ^ pad workspace name in button
   , useImages        :: Bool             -- ^ use images in the workspace switcher
   , imageSize        :: Int              -- ^ image height and width in pixels
   , fillEmptyImages  :: Bool             -- ^ fill empty images instead of clearing them
@@ -94,6 +95,7 @@ defaultPagerConfig   = PagerConfig
   , urgentWorkspace  = colorize "red" "yellow" . escape
   , widgetSep        = " : "
   , workspaceGap     = 0
+  , workspacePad     = True
   , useImages        = False
   , imageSize        = 16
   , fillEmptyImages  = False

--- a/src/System/Taffybar/Pager.hs
+++ b/src/System/Taffybar/Pager.hs
@@ -67,6 +67,7 @@ data PagerConfig = PagerConfig
   , visibleWorkspace :: String -> String -- ^ all other visible workspaces (Xinerama or XRandR).
   , urgentWorkspace  :: String -> String -- ^ workspaces containing windows with the urgency hint set.
   , widgetSep        :: String           -- ^ separator to use between desktop widgets in 'TaffyPager'.
+  , workspaceGap     :: Int              -- ^ space in pixels between workspace buttons
   , useImages        :: Bool             -- ^ use images in the workspace switcher
   , imageSize        :: Int              -- ^ image height and width in pixels
   , fillEmptyImages  :: Bool             -- ^ fill empty images instead of clearing them
@@ -92,6 +93,7 @@ defaultPagerConfig   = PagerConfig
   , visibleWorkspace = wrap "(" ")" . escape
   , urgentWorkspace  = colorize "red" "yellow" . escape
   , widgetSep        = " : "
+  , workspaceGap     = 0
   , useImages        = False
   , imageSize        = 16
   , fillEmptyImages  = False

--- a/src/System/Taffybar/Pager.hs
+++ b/src/System/Taffybar/Pager.hs
@@ -67,6 +67,7 @@ data PagerConfig = PagerConfig
   , visibleWorkspace :: String -> String -- ^ all other visible workspaces (Xinerama or XRandR).
   , urgentWorkspace  :: String -> String -- ^ workspaces containing windows with the urgency hint set.
   , widgetSep        :: String           -- ^ separator to use between desktop widgets in 'TaffyPager'.
+  , workspaceBorder  :: Bool             -- ^ wrap workspace buttons in a frame
   , workspaceGap     :: Int              -- ^ space in pixels between workspace buttons
   , workspacePad     :: Bool             -- ^ pad workspace name in button
   , useImages        :: Bool             -- ^ use images in the workspace switcher
@@ -94,6 +95,7 @@ defaultPagerConfig   = PagerConfig
   , visibleWorkspace = wrap "(" ")" . escape
   , urgentWorkspace  = colorize "red" "yellow" . escape
   , widgetSep        = " : "
+  , workspaceBorder  = False
   , workspaceGap     = 0
   , workspacePad     = True
   , useImages        = False

--- a/src/System/Taffybar/WorkspaceSwitcher.hs
+++ b/src/System/Taffybar/WorkspaceSwitcher.hs
@@ -94,7 +94,7 @@ type ImageChoice = (Maybe EWMHIcon, Maybe FilePath, Maybe ColorRGBA)
 -- its source of events.
 wspaceSwitcherNew :: Pager -> IO Gtk.Widget
 wspaceSwitcherNew pager = do
-  switcher <- Gtk.hBoxNew False 0
+  switcher <- Gtk.hBoxNew False (workspaceGap (config pager))
   desktop  <- getDesktop pager
   deskRef  <- MV.newMVar desktop
   populateSwitcher switcher deskRef

--- a/taffybar.rc
+++ b/taffybar.rc
@@ -21,6 +21,27 @@ style "taffybar-notification-button" = "taffybar-default" {
   fg[NORMAL]   = @red
 }
 
+style "taffybar-workspace-border-active" = "taffybar-default" {
+  bg[NORMAL] = @white
+}
+style "taffybar-workspace-border-visible" = "taffybar-default" {
+  bg[NORMAL] = @white
+}
+style "taffybar-workspace-border-empty" = "taffybar-default" {
+  bg[NORMAL] = @white
+}
+style "taffybar-workspace-border-hidden" = "taffybar-default" {
+  bg[NORMAL] = @white
+}
+style "taffybar-workspace-border-urgent" = "taffybar-default" {
+  bg[NORMAL] = @white
+}
+
 widget "Taffybar*" style "taffybar-default"
 widget "Taffybar*WindowSwitcher*label" style "taffybar-active-window"
 widget "*NotificationCloseButton" style "taffybar-notification-button"
+widget "*Workspace-*-active*" style "taffybar-workspace-border-active"
+widget "*Workspace-*-visible*" style "taffybar-workspace-border-visible"
+widget "*Workspace-*-empty*" style "taffybar-workspace-border-empty"
+widget "*Workspace-*-hidden*" style "taffybar-workspace-border-hidden"
+widget "*Workspace-*-urgent*" style "taffybar-workspace-border-urgent"


### PR DESCRIPTION
- all options are disabled by default, non-breaking change
- add an option to pager config to skip pre-pending a space to non-empty workspaces
- add an option to pager config to add a gap in pixels between workspaces
- add an option to pager config to draw a border around workspace buttons
- add gtkrc styles for custom borders in `taffybar.rc`

these options are particularly useful for configuring the workspace images UI

`my config (requires workspace-images code)`
![20161126_ss4](https://cloud.githubusercontent.com/assets/592062/20645850/dbbec692-b438-11e6-878b-0ac1dea418b8.png)
