### PR TITLE
Add _NET_WM_DESKTOP event for i3wm compatibility

### DIFF
--- a/src/System/Taffybar/WorkspaceSwitcher.hs
+++ b/src/System/Taffybar/WorkspaceSwitcher.hs
@@ -106,6 +106,7 @@ wspaceSwitcherNew pager = do
       redrawcb = redrawCallback pager deskRef switcher
       urgentcb = urgentCallback cfg deskRef
   subscribe pager activecb "_NET_CURRENT_DESKTOP"
+  subscribe pager activecb "_NET_WM_DESKTOP"
   subscribe pager redrawcb "_NET_DESKTOP_NAMES"
   subscribe pager redrawcb "_NET_NUMBER_OF_DESKTOPS"
   subscribe pager urgentcb "WM_HINTS"


### PR DESCRIPTION
Fix partially broken workspace information in i3wm with Taffybar.

Without this fix, if you move from one empty workspace to another in i3, it has no effect on the workspace switcher.