### PR TITLE
Add Icon widgets

### DIFF
--- a/src/System/Taffybar/Widgets/Icon.hs
+++ b/src/System/Taffybar/Widgets/Icon.hs
@@ -1,0 +1,58 @@
+-- | This is a simple static image widget, and a polling image widget that
+-- updates its contents by calling a callback at a set interval.
+module System.Taffybar.Widgets.Icon
+(
+  iconImageWidgetNew,
+  pollingIconImageWidgetNew
+) where
+
+import Control.Concurrent ( forkIO, threadDelay )
+import Control.Exception as E
+import Control.Monad ( forever )
+import Graphics.UI.Gtk
+
+-- | Create a new widget that displays a static image
+--
+-- > iconImageWidgetNew path
+--
+-- returns a widget with icon at @path@.
+iconImageWidgetNew :: FilePath -> IO Widget
+iconImageWidgetNew path = do
+  box <- hBoxNew False 0
+  icon <- imageNewFromFile path
+  boxPackStart box icon PackNatural 0
+  widgetShowAll box
+  return $ toWidget box
+
+-- | Create a new widget that updates itself at regular intervals.  The
+-- function
+--
+-- > pollingIconImageWidgetNew path interval cmd
+--
+-- returns a widget with initial icon at @path@.  The widget
+-- forks a thread to update its contents every @interval@ seconds.
+-- The command should return a FilePath of a valid icon.
+--
+-- If the IO action throws an exception, it will be swallowed and the
+-- label will not update until the update interval expires.
+pollingIconImageWidgetNew :: FilePath       -- ^ Initial file path of the icon
+                             -> Double      -- ^ Update interval (in seconds)
+                             -> IO FilePath -- ^ Command to run to get the input filepath
+                             -> IO Widget
+pollingIconImageWidgetNew path interval cmd = do
+  box <- hBoxNew False 0
+  icon <- imageNewFromFile path
+  on icon realize $ do
+    forkIO $ forever $ do
+      let tryUpdate = do
+            str <- cmd
+            postGUIAsync $ imageSetFromFile icon str
+      E.catch tryUpdate ignoreIOException
+      threadDelay $ floor (interval * 1000000)
+    return ()
+  boxPackStart box icon PackNatural 0
+  widgetShowAll box
+  return $ toWidget box
+
+ignoreIOException :: IOException -> IO ()
+ignoreIOException _ = return ()

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -85,6 +85,7 @@ library
                    System.Taffybar.Text.CPUMonitor,
                    System.Taffybar.Text.MemoryMonitor,
                    System.Taffybar.Widgets.Graph,
+                   System.Taffybar.Widgets.Icon,
                    System.Taffybar.Widgets.PollingBar,
                    System.Taffybar.WindowSwitcher,
                    System.Taffybar.IconImages,


### PR DESCRIPTION
I wrote this a while ago, and have been using it to display static and dynamic icons in taffybar.

For an example of a dynamic icon, consider an icon which indicates whether a laptop is on AC or battery:

in `taffybar.hs`

```haskell
batteryIconFunc :: BatteryContext -> String -> IO String
batteryIconFunc ctxt prefix = do
  ac <- batteryAC ctxt
  percentage <- batteryPercent ctxt
  case () of
    _ | ac == BatteryStateCharging -> return $ prefix ++ "ac_01.xpm"
      | percentage < 0.1 -> return $ prefix ++ "bat_empty_02.xpm"
      | percentage < 0.4 -> return $ prefix ++ "bat_low_02.xpm"
      | otherwise -> return $ prefix ++ "bat_full_02.xpm"

batteryPercent :: BatteryContext -> IO Double
batteryPercent ctxt = do
  info <- getBatteryInfo ctxt
  return (batteryPercentage (fromJust info) / 100)

batteryAC :: BatteryContext -> IO BatteryState
batteryAC ctxt = do
  info <- getBatteryInfo ctxt
  return . batteryState $ fromJust info
```

where `prefix` is something like `/home/nick/icons/`

I don't know if this duplicates functionality of System.Taffybar.IconImages, because I can't understand what that does - feedback appreciated.