### PR TITLE
add optional activeLayoutIO to pagerConfig (non-breaking change)

### DIFF
--- a/src/System/Taffybar/LayoutSwitcher.hs
+++ b/src/System/Taffybar/LayoutSwitcher.hs
@@ -77,8 +77,8 @@ layoutSwitcherNew pager = do
 pagerCallback :: PagerConfig -> Gtk.Label -> Event -> PagerIO ()
 pagerCallback cfg label _ = do
   layout <- liftPagerX11 $ readAsString Nothing xLayoutProp
-  let decorate = activeLayout cfg
-  lift $ Gtk.labelSetMarkup label (decorate layout)
+  markup <- lift $ activeLayoutIO cfg $ activeLayout cfg layout
+  lift $ Gtk.labelSetMarkup label markup
 
 -- | Build the graphical representation of the widget.
 assembleWidget :: Pager -> Gtk.Label -> IO Gtk.Widget

--- a/src/System/Taffybar/Pager.hs
+++ b/src/System/Taffybar/Pager.hs
@@ -70,6 +70,8 @@ data PagerConfig = PagerConfig
   -- ^ the name of the active window.
   , activeLayout            :: String -> String
   -- ^ the currently active layout.
+  , activeLayoutIO          :: String -> IO String
+  -- ^ IO action to modify active layout.
   , activeWorkspace         :: String -> String
   -- ^ the currently active workspace.
   , hiddenWorkspace         :: String -> String
@@ -126,6 +128,7 @@ defaultPagerConfig :: PagerConfig
 defaultPagerConfig = PagerConfig
   { activeWindow            = escape . shorten 40
   , activeLayout            = escape
+  , activeLayoutIO          = return
   , activeWorkspace         = colorize "yellow" "" . wrap "[" "]" . escape
   , hiddenWorkspace         = escape
   , emptyWorkspace          = const ""


### PR DESCRIPTION
non-breaking change to active-layout to allow further customizing layout with markup.

i use this to add a count of windows in full-screen-mode "[5]"
```
activeLayoutIO   = \layout -> case layout of
      "left"    -> return "[]="
      "top"     -> return "TTT"
      "grid"    -> return "###"
      "full"    -> do
        cnt <- windowCount
        let numFmt = if 0 <= cnt && cnt < 10 then show cnt else "+"
        let color = if cnt > 1 then fgbg "blue" "red" else id
        return $ color $ "[" ++ numFmt ++ "]"
```