### PR TITLE
workspace-images: fix preferCustomIcon

### DIFF
--- a/src/System/Taffybar/Pager.hs
+++ b/src/System/Taffybar/Pager.hs
@@ -92,10 +92,8 @@ data PagerConfig = PagerConfig
   , imageSize               :: Int
   -- ^ fill empty images instead of clearing them
   , fillEmptyImages         :: Bool
-  -- ^ use custom icons over EWHMIcons
-  , preferCustomIcon        :: Bool
-  -- ^ get icon based on window title and class
-  , customIcon              :: String -> String -> Maybe FilePath
+  -- ^ get custom icon based on: has-EWMH-icon, window-title, window-class
+  , customIcon              :: Bool -> String -> String -> Maybe FilePath
   -- ^ title windows for WindowSwitcher
   , windowSwitcherFormatter :: M.Map WorkspaceIdx String -> X11WindowHandle -> String
   }
@@ -134,8 +132,7 @@ defaultPagerConfig   = PagerConfig
   , useImages               = False
   , imageSize               = 16
   , fillEmptyImages         = False
-  , preferCustomIcon        = False
-  , customIcon              = \_ _ -> Nothing
+  , customIcon              = \_ _ _ -> Nothing
   , windowSwitcherFormatter = defaultFormatEntry
   }
 

--- a/src/System/Taffybar/WorkspaceSwitcher.hs
+++ b/src/System/Taffybar/WorkspaceSwitcher.hs
@@ -54,7 +54,7 @@ data Workspace = Workspace { label     :: Gtk.Label
                            }
 type WindowSet = [(WorkspaceIdx, [X11Window])]
 type WindowInfo = Maybe (String, String, [EWMHIcon])
-type CustomIconF = String -> String -> Maybe FilePath
+type CustomIconF = Bool -> String -> String -> Maybe FilePath
 type ImageChoice = (Maybe EWMHIcon, Maybe FilePath, Maybe ColorRGBA)
 
 -- $usage
@@ -289,18 +289,17 @@ transition cfg desktop wss = do
       fillEmpty = fillEmptyImages cfg
       imgSize = imageSize cfg
       customIconF = customIcon cfg
-      preferCustom = preferCustomIcon cfg
-  when useImg $ updateImages desktop imgSize fillEmpty preferCustom customIconF
+  when useImg $ updateImages desktop imgSize fillEmpty customIconF
 
 -- | Update the GTK images using X properties.
-updateImages :: Desktop -> Int -> Bool -> Bool -> CustomIconF -> IO ()
-updateImages desktop imgSize fillEmpty preferCustom customIconF = do
+updateImages :: Desktop -> Int -> Bool -> CustomIconF -> IO ()
+updateImages desktop imgSize fillEmpty customIconF = do
   windowSet <- getWindowSet (allWorkspaces desktop)
   lastWinInfo <- getLastWindowInfo windowSet
   let images = map image desktop
       fillColor = if fillEmpty then Just (0, 0, 0, 0) else Nothing
       imageChoices = getImageChoices lastWinInfo customIconF fillColor imgSize
-  zipWithM_ (setImage imgSize preferCustom) images imageChoices
+  zipWithM_ (setImage imgSize) images imageChoices
 
 -- | Get EWMHIcons, custom icon files, and fill colors based on the window info.
 getImageChoices :: [WindowInfo] -> CustomIconF -> Maybe ColorRGBA -> Int -> [ImageChoice]
@@ -322,17 +321,16 @@ selectEWMHIcon _ _ = Nothing
 
 -- | Select a file using customIcon config.
 selectCustomIconFile :: CustomIconF -> WindowInfo -> Maybe FilePath
-selectCustomIconFile customIconF (Just (wTitle, wClass, _)) = customIconF wTitle wClass
+selectCustomIconFile customIconF (Just (wTitle, wClass, icons)) = customIconF (length icons > 0) wTitle wClass
 selectCustomIconFile _ _ = Nothing
 
 -- | Sets an image based on the image choice (EWMHIcon, custom file, and fill color).
-setImage :: Int -> Bool -> Gtk.Image -> ImageChoice -> IO ()
-setImage imgSize preferCustom img imgChoice = setImgAct imgChoice preferCustom
-  where setImgAct (_, Just file, _) True = setImageFromFile img imgSize file
-        setImgAct (Just icon, _, _) _    = setImageFromEWMHIcon img imgSize icon
-        setImgAct (_, Just file, _) _    = setImageFromFile img imgSize file
-        setImgAct (_, _, Just color) _   = setImageFromColor img imgSize color
-        setImgAct _ _                    = Gtk.imageClear img
+setImage :: Int -> Gtk.Image -> ImageChoice -> IO ()
+setImage imgSize img imgChoice = setImgAct imgChoice
+  where setImgAct (_, Just file, _)      = setImageFromFile img imgSize file
+        setImgAct (Just icon, _, _)      = setImageFromEWMHIcon img imgSize icon
+        setImgAct (_, _, Just color)     = setImageFromColor img imgSize color
+        setImgAct _                      = Gtk.imageClear img
 
 -- | Create a pixbuf from the pixel data in an EWMHIcon,
 -- scale it square, and set it in a GTK Image.


### PR DESCRIPTION
tested in `WSS` and `WSHUD`

the old prefer-custom-icon behaviour makes `preferCustomIcon=True` useless, as it always overrides the EWMH icon if you use an "unknown" icon.

this replaces the boolean `preferCustomIcon` with a boolean `hasIcon` param to `customIcon`, letting the pager config handle the situation intelligently.

this also allows case-by-case basis for preferring custom icon.
(i use this to override "unknown" icon and also certain websites in firefox, and otherwise prefer system icon instead of custom)

for folks that use custom icon, this requires tiny change to pagerConfig. if you use system icons only, no change required.
`customIcon t c -> fct t c,` => `customIcon _ t c -> fct t c,`


