### PR TITLE
Improved the FreedesktopNotifications widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
  * Quick start script for installing from git with stack (Ivan Malison)
  * Add a volume widget (Nick Hu and Abdul Sattar)
  * Add available memory field to MemoryInfo (Will Price)
+ * The freedesktop.org notifications widget now allows for notifications to never expire and can handle multiple notifications at once. In particular the default formatter now shows the number of pending notifications (Daniel Oliveira)
 
 ...and many smaller tweaks.
 

--- a/src/System/Taffybar/FreedesktopNotifications.hs
+++ b/src/System/Taffybar/FreedesktopNotifications.hs
@@ -115,7 +115,7 @@ notify :: NotifyState
        -> Int32 -- ^ Expires timeout (milliseconds)
        -> IO Word32
 notify s appName replaceId _ summary body _ _ timeout = do
-  realId <- if replaceId == 0 then noteFreshId s else pure replaceId
+  realId <- if replaceId == 0 then noteFreshId s else return replaceId
   let escapeText = T.pack . escapeMarkup . T.unpack
       configTimeout = notificationMaxTimeout (noteConfig s)
       realTimeout = if timeout <= 0 -- Gracefully handle out of spec negative values
@@ -154,12 +154,12 @@ notificationDaemon onNote onCloseNote = do
   export client "/org/freedesktop/Notifications" interface
   where
     getServerInformation :: IO (Text, Text, Text, Text)
-    getServerInformation = pure ("haskell-notification-daemon",
-                                 "nochair.net",
-                                 "0.0.1",
-                                 "1.1")
+    getServerInformation = return ("haskell-notification-daemon",
+                                   "nochair.net",
+                                   "0.0.1",
+                                   "1.1")
     getCapabilities :: IO [Text]
-    getCapabilities = pure ["body", "body-markup"]
+    getCapabilities = return ["body", "body-markup"]
     interface = defaultInterface
       { interfaceName = "org.freedesktop.Notifications"
       , interfaceMethods =

--- a/src/System/Taffybar/FreedesktopNotifications.hs
+++ b/src/System/Taffybar/FreedesktopNotifications.hs
@@ -181,7 +181,7 @@ displayThread s = forever $ do
   ns <- readTVarIO (noteQueue s)
   postGUIAsync $
     if S.length ns == 0
-    then widgetHideAll (noteContainer s)
+    then widgetHide (noteContainer s)
     else do
       labelSetMarkup (noteWidget s) $ formatMessage (noteConfig s) (toList ns)
       widgetShowAll (noteContainer s)

--- a/src/System/Taffybar/FreedesktopNotifications.hs
+++ b/src/System/Taffybar/FreedesktopNotifications.hs
@@ -200,8 +200,8 @@ startTimeoutThread s (Notification {..}) = case noteExpireTimeout of
 
 --------------------------------------------------------------------------------
 data NotificationConfig =
-  NotificationConfig { notificationMaxTimeout :: Maybe Int32 -- ^ Maximum time that a notification will be displayed (in seconds).  Default: 10
-                     , notificationMaxLength :: Int  -- ^ Maximum length displayed, in characters.  Default: 50
+  NotificationConfig { notificationMaxTimeout :: Maybe Int32 -- ^ Maximum time that a notification will be displayed (in seconds).  Default: None
+                     , notificationMaxLength :: Int  -- ^ Maximum length displayed, in characters.  Default: 100
                      , notificationFormatter :: [Notification] -> String -- ^ Function used to format notifications, takes the notifications from first to last
                      }
 


### PR DESCRIPTION
Instead of having a separate current notification in noteCurrent, we can just take the current notification to be the first one in noteQueue. This greatly simplifies the code.

Allowed notifications to never timeout by wrapping notificationMaxTimeout in a Maybe.
Set Nothing to be the default.

We can pass the whole sequence to the formatter to do interesting things with it.
Changed the default formatter so that it displays the number of pending notifications.

The displayThread now only handles displaying the notification, in particular the timeout thread is started by notify instead.
