### PR TITLE
Add available memory field to MemoryInfo

### DIFF
--- a/src/System/Information/Memory.hs
+++ b/src/System/Information/Memory.hs
@@ -14,25 +14,27 @@ data MemoryInfo = MemoryInfo { memoryTotal :: Double
                              , memorySwapFree :: Double
                              , memorySwapUsed :: Double -- swapTotal - swapFree
                              , memorySwapUsedRatio :: Double -- swapUsed / swapTotal
+                             , memoryAvailable :: Double -- An estimate of how much memory is available for starting new apps
                              , memoryRest :: Double      -- free + buffer + cache
                              , memoryUsed :: Double      -- total - rest
                              , memoryUsedRatio :: Double -- used / total
                              }
 
 emptyMemoryInfo :: MemoryInfo
-emptyMemoryInfo = MemoryInfo 0 0 0 0 0 0 0 0 0 0 0
+emptyMemoryInfo = MemoryInfo 0 0 0 0 0 0 0 0 0 0 0 0
 
 parseLines :: [String] -> MemoryInfo -> MemoryInfo
 parseLines (line:rest) memInfo = parseLines rest newMemInfo
   where (label:size:_) = words line
         newMemInfo = case label of
-                       "MemTotal:"   -> memInfo { memoryTotal = toMB size }
-                       "MemFree:"    -> memInfo { memoryFree = toMB size }
-                       "Buffers:"    -> memInfo { memoryBuffer = toMB size }
-                       "Cached:"     -> memInfo { memoryCache = toMB size }
-                       "SwapTotal:"  -> memInfo { memorySwapTotal = toMB size }
-                       "SwapFree:"   -> memInfo { memorySwapFree = toMB size }
-                       _             -> memInfo
+                       "MemTotal:"     -> memInfo { memoryTotal = toMB size }
+                       "MemFree:"      -> memInfo { memoryFree = toMB size }
+                       "MemAvailable:" -> memInfo { memoryAvailable = toMB size }
+                       "Buffers:"      -> memInfo { memoryBuffer = toMB size }
+                       "Cached:"       -> memInfo { memoryCache = toMB size }
+                       "SwapTotal:"    -> memInfo { memorySwapTotal = toMB size }
+                       "SwapFree:"     -> memInfo { memorySwapFree = toMB size }
+                       _               -> memInfo
 parseLines _ memInfo = memInfo
 
 parseMeminfo :: IO MemoryInfo


### PR DESCRIPTION
On my system, `cat /proc/meminfo` yields:

```
MemTotal:       16289508 kB
MemFree:         1059928 kB
MemAvailable:    6774876 kB
Buffers:          954708 kB
Cached:          2824500 kB
SwapCached:           28 kB
...
```

Using the previously calculation of free memory `rest = free + buffer + cache`
yields 4839136 kB, which is substantially different to `MemAvailable`. I
wish to chart `(MemTotal - MemAvailable)/MemTotal` as a more accurate
statistic of how much RAM on my system is being used