### PR TITLE
Add 'usePrimaryMonitor' function for 'getMonitorConfig' option

### DIFF
--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -179,6 +179,7 @@ module System.Taffybar (
   taffybarMain,
   allMonitors,
   useMonitorNumber,
+  usePrimaryMonitor,
   ) where
 
 import qualified Config.Dyre as Dyre
@@ -194,6 +195,7 @@ import Safe ( atMay )
 import System.Environment.XDG.BaseDir ( getUserConfigFile )
 import System.Exit ( exitFailure )
 import System.FilePath ( (</>) )
+import System.Information.X11DesktopInfo
 import qualified System.IO as IO
 import System.Mem.StableName
 import Text.Printf ( printf )
@@ -257,6 +259,13 @@ useMonitorNumber c@(cfg, _) = return umn
   where umn mnumber
             | mnumber == monitorNumber cfg = Just c
             | otherwise = Nothing
+
+-- | Use the primary monitor as set by Xrandr.
+usePrimaryMonitor :: TaffybarConfigEQ -> IO (Int -> Maybe TaffybarConfigEQ)
+usePrimaryMonitor c@(cfg, _) = do
+  maybePrimary <- withDefaultCtx getPrimaryOutputNumber
+  let primary = maybe (monitorNumber cfg) id maybePrimary
+  return $ \mnumber -> if mnumber == primary then Just c else Nothing
 
 allMonitors :: TaffybarConfigEQ -> IO (Int -> Maybe TaffybarConfigEQ)
 allMonitors cfg = return $ const $ Just cfg

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -127,7 +127,11 @@ executable taffybar
                  safe >= 0.3 && < 1,
                  xdg-basedir,
                  X11 >= 1.5.0.1,
-                 filepath
+                 filepath,
+                 utf8-string,
+                 mtl >= 2,
+                 split >= 0.1.4.2,
+                 taffybar
   hs-source-dirs: src
   main-is: Main.hs
   other-modules: System.Taffybar


### PR DESCRIPTION
This function uses Xrandr library to determine the primary monitor number.  If a primary monitor isn't set or otherwise can't be determined, the function falls back to the `monitorNumber` config option.

See: https://github.com/travitch/taffybar/pull/155

I debated about whether to add this functionality to existing modules or implement it separately, like `System.Taffybar.ToggleMonitor`.  I decided to implement it in the existing modules because it seems to fit in and it seems like a basic option that users would expect to be built-in.