### PR TITLE
WorkspaceHUD: Fix urgent state + export WorkspaceState

### DIFF
--- a/src/System/Taffybar/WorkspaceHUD.hs
+++ b/src/System/Taffybar/WorkspaceHUD.hs
@@ -22,6 +22,7 @@ module System.Taffybar.WorkspaceHUD (
   WorkspaceButtonController(..),
   WorkspaceContentsController(..),
   WorkspaceHUDConfig(..),
+  WorkspaceState(..),
   WorkspaceUnderlineController(..),
   WorkspaceWidgetController(..),
   IconController(..),

--- a/src/System/Taffybar/WorkspaceHUD.hs
+++ b/src/System/Taffybar/WorkspaceHUD.hs
@@ -57,7 +57,7 @@ import           Control.Monad.Reader
 import           Control.RateLimit
 import qualified Data.Char as S
 import qualified Data.Foldable as F
-import           Data.List (sortBy)
+import           Data.List (intersect, sortBy)
 import qualified Data.Map as M
 import           Data.Maybe
 import qualified Data.MultiMap as MM
@@ -338,10 +338,10 @@ buildWorkspaces _ = ask >>= \context -> liftX11Def M.empty $ do
   activeWindows <- readAsListOfWindow Nothing "_NET_ACTIVE_WINDOW"
   active:visible <- getVisibleWorkspaces
   let getWorkspaceState idx ws
-        | urgentWorkspaceState (hudConfig context) && not (null urgentWindows) =
-          Urgent
         | idx == active = Active
         | idx `elem` visible = Visible
+        | urgentWorkspaceState (hudConfig context) && not (null (ws `intersect` urgentWindows)) =
+          Urgent
         | null ws = Empty
         | otherwise = Hidden
   foldM


### PR DESCRIPTION
This is a pair of small commits that I can break out into separate PRs if desired.

1. Export `WorkspaceState` data type so that custom `labelSetter` functions can be defined based on the workspace state (active, urgent, etc.).

2. Set the urgent state only on workspaces containing urgent windows.  This fixes (imo) a bug where all of the workspaces would be marked urgent, even if only one of them contained an urgent window.  I've also prioritized the active and visible state over the urgent state, which is how the WorkspaceSwitcher widget behaves, namely that I only need to be specially notified of an urgent window if I can't already see it.




And just a quick note not necessarily related to this PR:

Thank you, @IvanMalison!  When in #229 (which is awesome) you suggested deprecating the WorkspaceSwitcher widget, I was apprehensive because I thought the HUD widget was strictly about eye candy when I really like my simple text-based switcher.  But over the course of the afternoon I was able to get my exact switcher configuration working with the HUD widget, and got to eliminate some of my hacks in the process.  I love it!

![screenshot_20171015_221318](https://user-images.githubusercontent.com/646230/31592427-260bf948-b1f6-11e7-8751-1c8f559beb06.png)
(my pager showing active, visible, and urgent workspaces)

```haskell
workspaceHUDConfig :: WorkspaceHUDConfig
workspaceHUDConfig = defaultWorkspaceHUDConfig
    { widgetBuilder        = buildButtonController buildLabelController
    , minWSWidgetSize      = Nothing
    , labelSetter          = workspaceHUDLabelSetter
    , showWorkspaceFn      = hideEmpty
    , urgentWorkspaceState = True
    }

workspaceHUDLabelSetter :: Workspace -> HUDIO String
workspaceHUDLabelSetter workspace = do
    workspacesRef <- asks workspacesVar
    workspaces    <- lift $ readMVar workspacesRef
    let nonEmptyWorkspaces  = filter (\(_, w) -> workspaceState w /= Empty) $ M.toList workspaces
    let (lastWsIdx, _)      = last nonEmptyWorkspaces
    let wsIdx@(WSIdx wsNum) = workspaceIdx workspace
    let endMarker           = if wsIdx == lastWsIdx then "\x00a0" else ""
    let name                = escape $ (show $ wsNum + 1) ++ ": " ++ workspaceName workspace ++ endMarker
    return $ case workspaceState workspace of
        Active  -> workspaceDecorator "#282828" "#7cafc2" True $ name
        Visible -> workspaceDecorator "#d8d8d8" "#383838" False $ name
        Hidden  -> workspaceDecorator "#d8d8d8" "#282828" False $ name
        Urgent  -> workspaceDecorator "#282828" "#f7ca88" False $ name
        Empty   -> name
  where
    workspaceDecorator is the same decorator function I used
      in my WorkspaceSwitcher widget configuration
```
