### PR TITLE
Handle cases where a config dir exists but the menu file in it does not

### DIFF
--- a/src/System/Taffybar/Util.hs
+++ b/src/System/Taffybar/Util.hs
@@ -8,11 +8,13 @@
 -- Stability   : unstable
 -- Portability : unportable
 
-module System.Taffybar.Util (
-  (??)
-) where
+module System.Taffybar.Util where
 
 infixl 4 ??
 (??) :: Functor f => f (a -> b) -> a -> f b
 fab ?? a = fmap ($ a) fab
 {-# INLINE (??) #-}
+
+ifM :: Monad m => m Bool -> m a -> m a -> m a
+ifM cond whenTrue whenFalse =
+  cond >>= (\bool -> if bool then whenTrue else whenFalse)


### PR DESCRIPTION
Don't give up after checking the first one; continue down the list of
possible paths until we find a menu file that exists.

More fixes for #240