### PR TITLE
Bump time version bound to support GHC 8.2

### DIFF
--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -52,7 +52,7 @@ library
                  split >= 0.1.4.2,
                  stm,
                  text,
-                 time >= 1.4 && < 1.7,
+                 time >= 1.4 && < 1.9,
                  time-locale-compat >= 0.1 && < 0.2,
                  time-units >= 1.0.0,
                  transformers >= 0.3.0.0,


### PR DESCRIPTION
GHC 8.2.2 comes with time-1.8.0.2, which this still works with.