### PR TITLE
Expose pollingBarNew sans threadDelay

### DIFF
--- a/src/System/Taffybar/Widgets/Util.hs
+++ b/src/System/Taffybar/Widgets/Util.hs
@@ -14,11 +14,12 @@
 
 module System.Taffybar.Widgets.Util where
 
-import Control.Monad
+import Control.Monad ( when, forever, void )
 import Control.Monad.IO.Class
+import Data.Functor ( ($>) )
 import Data.Tuple.Sequence
+import Control.Concurrent ( forkIO )
 import Graphics.UI.Gtk
-import Prelude
 import Text.Printf
 
 -- | Execute the given action as a response to any of the given types
@@ -74,6 +75,7 @@ widgetGetAllocatedSize widget =
   liftIO $
   sequenceT (widgetGetAllocatedWidth widget, widgetGetAllocatedHeight widget)
 
+
 -- | Creates markup with the given foreground and background colors and the
 -- given contents.
 colorize :: String -- ^ Foreground color.
@@ -84,3 +86,9 @@ colorize fg bg = printf "<span%s%s>%s</span>" (attr "fg" fg) (attr "bg" bg)
   where attr name value
           | null value = ""
           | otherwise  = printf " %scolor=\"%s\"" name value
+
+backgroundLoop :: IO a -> IO ()
+backgroundLoop = void . forkIO . forever
+
+drawOn :: WidgetClass object => object -> IO () -> IO object
+drawOn drawArea action = on drawArea realize action $> drawArea


### PR DESCRIPTION
For displaying e.g. screen brightness, I figured using poll(2) or select
or the like would be more efficient and give better response times than
simply reading the file at a periodic interval.

The bulk of that function looks the same as the existing pollingBarNew,
just without the threadDelay - the existing function can be implemented
in terms of the "new" one just by tacking on a threadDelay to the
action.

For my use with "polling" the value out of /sys/class/backlight/intel_backlight/actual_brightness, my invocation of this looks something like `verticalBarFromCallback cfg $ readNum path <* watchFile path`, where `watchFile is a wrapper for https://github.com/quixoftic/hpio/blob/master/src/System/GPIO/Linux/Sysfs/IO.hs#L132, so it will just block that thread until that file changes.

Not sure what good naming for this stuff is.