### PR TITLE
Fix WttrIn widget

### DIFF
--- a/src/System/Taffybar/Widget/WttrIn.hs
+++ b/src/System/Taffybar/Widget/WttrIn.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 -- | This is a simple weather widget that polls wttr.in to retrieve the weather,
 -- instead of relying on noaa data.
 --
@@ -6,21 +7,29 @@
 -- better.
 --
 -- For more information on how to use wttr.in, see <https://wttr.in/:help>.
+module System.Taffybar.Widget.WttrIn (textWttrNew) where
 
-module System.Taffybar.Widget.WttrIn ( textWttrNew ) where
-import System.Log.Logger
-import Control.Exception as E
-import Control.Monad.IO.Class
-import GI.Gtk
-import qualified Data.Text as T
-import Data.Maybe (isJust)
-import Data.Text.Encoding (decodeUtf8)
-import Data.ByteString.Lazy (toStrict)
+import Control.Exception as E (handle)
+import Control.Monad.IO.Class (MonadIO)
 import Data.ByteString (ByteString)
-import Text.Regex
+import Data.ByteString.Lazy (toStrict)
+import Data.Maybe (isJust)
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8)
+import GI.Gtk (Widget)
 import Network.HTTP.Client
+  ( HttpException,
+    Request (requestHeaders),
+    Response (responseBody, responseStatus),
+    defaultManagerSettings,
+    httpLbs,
+    newManager,
+    parseRequest,
+  )
 import Network.HTTP.Types.Status (statusIsSuccessful)
-import System.Taffybar.Widget.Generic.PollingLabel
+import System.Log.Logger (Priority (ERROR), logM)
+import System.Taffybar.Widget.Generic.PollingLabel (pollingLabelNew)
+import Text.Regex (matchRegex, mkRegex)
 
 -- | Creates a GTK Label widget that polls the requested wttr.in url for weather
 -- information.
@@ -31,36 +40,51 @@ import System.Taffybar.Widget.Generic.PollingLabel
 -- > -- Yields a label with the text "London: ⛅️  +72°F". Updates every 60
 -- > -- seconds.
 -- > textWttrNew "http://wttr.in/London?format=3" 60
-textWttrNew
- :: MonadIO m
- => String -- ^ URL. All non-alphanumeric characters must be properly %-encoded.
- -> Double -- ^ Update Interval (in seconds)
- -> m Widget
+textWttrNew ::
+  MonadIO m =>
+  -- | URL. All non-alphanumeric characters must be properly %-encoded.
+  String ->
+  -- | Update Interval (in seconds)
+  Double ->
+  m Widget
 textWttrNew url interval = pollingLabelNew interval (callWttr url)
 
 -- | IO Action that calls wttr.in as per the user's request.
 callWttr :: String -> IO T.Text
-callWttr url = do
-  let unknownLocation rsp = -- checks for a common wttr.in bug
+callWttr url =
+  let unknownLocation rsp =
+        -- checks for a common wttr.in bug
         case T.stripPrefix "Unknown location; please try" rsp of
-          Nothing          -> False
+          Nothing -> False
           Just strippedRsp -> T.length strippedRsp < T.length rsp
-      isImage = isJust . (matchRegex $ mkRegex ".png")
-      getResponseData r = ( statusIsSuccessful $ responseStatus r
-                          , toStrict $ responseBody r)
-      catchAndLog = flip E.catch $ logException
-  manager <- newManager defaultManagerSettings
-  request <- parseRequest url
-  (isOk, response) <- catchAndLog (getResponseData <$> httpLbs request manager)
-  let body = decodeUtf8 response
-  if not isOk || isImage url || unknownLocation body
-  then return $ "✨"
-  else return $ body
+      isImage = isJust . matchRegex (mkRegex ".png")
+      getResponseData r =
+        ( statusIsSuccessful $ responseStatus r,
+          toStrict $ responseBody r
+        )
+   in do
+        manager <- newManager defaultManagerSettings
+        request <- parseRequest url
+        (isOk, response) <-
+          handle
+            logException
+            ( getResponseData
+                <$> httpLbs
+                  (request {requestHeaders = [("User-Agent", "curl")]})
+                  manager
+            )
+        let body = decodeUtf8 response
+        return $
+          if not isOk || isImage url || unknownLocation body
+            then "✨"
+            else body
 
 -- Logs an Http Exception and returns wttr.in's weather unknown label.
 logException :: HttpException -> IO (Bool, ByteString)
 logException e = do
   let errmsg = show e
-  logM "System.Taffybar.Widget.WttrIn" ERROR $
+  logM
+    "System.Taffybar.Widget.WttrIn"
+    ERROR
     ("Warning: Couldn't call wttr.in. \n" ++ errmsg)
-  return $ (False, "✨")
+  return (False, "✨")


### PR DESCRIPTION
The WttrIn widget currently gives you a TlsNotSupported error because:

1. the default `Network.HTTP.Client` configuration doesn't support HTTPS;
2. `wttr.in` redirects to HTTPS **except for certain user agents** (e.g. 'curl').

I've fixed that by spoofing the 'curl' UA, and also took the liberty of running it through a code formatter.