### PR TITLE
Handle DBus reconnects by re-establishing clients and hooks

### DIFF
--- a/src/System/Taffybar/DBus.hs
+++ b/src/System/Taffybar/DBus.hs
@@ -7,15 +7,12 @@ module System.Taffybar.DBus
   )
 where
 
-import Control.Monad.Trans.Class
-import Control.Monad.Trans.Reader
 import System.Log.DBus.Server
 import System.Taffybar.Context
 import System.Taffybar.DBus.Toggle
 
 startTaffyLogServer :: TaffyIO ()
-startTaffyLogServer =
-  asks sessionDBusClient >>= lift . startLogServer
+startTaffyLogServer = installSessionDBusClientHook startLogServer
 
 withLogServer :: TaffybarConfig -> TaffybarConfig
 withLogServer = appendHook startTaffyLogServer

--- a/src/System/Taffybar/DBus/Toggle.hs
+++ b/src/System/Taffybar/DBus/Toggle.hs
@@ -154,7 +154,6 @@ exportTogglesInterface = do
         toggleTaffyOnMon not $ fromMaybe 0 num
       takeInt :: (Int -> a) -> (Int32 -> a)
       takeInt = (. fromIntegral)
-  client <- asks sessionDBusClient
   let interface =
         defaultInterface
           { interfaceName = taffybarToggleInterface,
@@ -171,7 +170,7 @@ exportTogglesInterface = do
                 autoMethod "exit" $ exitTaffybar ctx
               ]
           }
-  lift $ do
+  installSessionDBusClientHook $ \client -> do
     _ <-
       requestName
         client

--- a/src/System/Taffybar/Information/ASUS.hs
+++ b/src/System/Taffybar/Information/ASUS.hs
@@ -260,7 +260,7 @@ readCpuTempC = do
 
 -- | Get current ASUS info using the system DBus client from Context.
 getASUSInfo :: TaffyIO ASUSInfo
-getASUSInfo = asks systemDBusClient >>= liftIO . getASUSInfoFromClient
+getASUSInfo = getSystemDBusClient >>= liftIO . getASUSInfoFromClient
 
 -- | Get current ASUS info from a DBus client.
 getASUSInfoFromClient :: Client -> IO ASUSInfo
@@ -317,7 +317,7 @@ registerForASUSPropertiesChanged ::
   (Signal -> String -> Map String Variant -> [String] -> IO ()) ->
   ReaderT Context IO SignalHandler
 registerForASUSPropertiesChanged signalHandler = do
-  client <- asks systemDBusClient
+  client <- getSystemDBusClient
   lift $
     DBus.registerForPropertiesChanged
       client

--- a/src/System/Taffybar/Information/Bluetooth.hs
+++ b/src/System/Taffybar/Information/Bluetooth.hs
@@ -45,7 +45,6 @@ import Control.Exception (SomeException, finally, try)
 import Control.Monad (forever)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.STM (atomically)
-import Control.Monad.Trans.Reader (asks)
 import DBus
 import DBus.Client
 import Data.List (sortOn)
@@ -56,7 +55,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Word (Word8)
 import System.Log.Logger (Priority (..))
-import System.Taffybar.Context (TaffyIO, getStateDefault, systemDBusClient)
+import System.Taffybar.Context (TaffyIO, getStateDefault, getSystemDBusClient)
 import System.Taffybar.Util (logPrintF)
 
 -- | Information about a Bluetooth device.
@@ -154,7 +153,7 @@ getBluetoothInfoState = do
 getBluetoothInfoChanVar :: TaffyIO BluetoothInfoChanVar
 getBluetoothInfoChanVar =
   getStateDefault $ do
-    client <- asks systemDBusClient
+    client <- getSystemDBusClient
     liftIO $ do
       chan <- newBroadcastTChanIO
       var <- newMVar defaultBluetoothInfo

--- a/src/System/Taffybar/Information/Inhibitor.hs
+++ b/src/System/Taffybar/Information/Inhibitor.hs
@@ -213,7 +213,7 @@ getInhibitorChan types = do
 toggleInhibitor :: [InhibitType] -> TaffyIO ()
 toggleInhibitor types = do
   ctx <- getInhibitorContext types
-  client <- asks systemDBusClient
+  client <- getSystemDBusClient
   liftIO $ modifyMVar_ (inhibitorFdVar ctx) $ \maybeFd -> do
     case maybeFd of
       Just fd -> do

--- a/src/System/Taffybar/Information/NetworkManager.hs
+++ b/src/System/Taffybar/Information/NetworkManager.hs
@@ -150,7 +150,7 @@ getWifiInfoChanVar =
 
 monitorWifiInfo :: TaffyIO (TChan WifiInfo, MVar WifiInfo)
 monitorWifiInfo = do
-  _client <- asks systemDBusClient
+  _client <- getSystemDBusClient
   infoVar <- lift $ newMVar wifiUnknownInfo
   chan <- liftIO newBroadcastTChanIO
   taffyFork $ do
@@ -167,7 +167,7 @@ registerForNetworkManagerPropertiesChanged ::
   (Signal -> String -> Map String Variant -> [String] -> IO ()) ->
   ReaderT Context IO SignalHandler
 registerForNetworkManagerPropertiesChanged signalHandler = do
-  client <- asks systemDBusClient
+  client <- getSystemDBusClient
   lift $
     DBus.registerForPropertiesChanged
       client
@@ -181,7 +181,7 @@ registerForActiveConnectionPropertiesChanged ::
   (Signal -> String -> Map String Variant -> [String] -> IO ()) ->
   ReaderT Context IO SignalHandler
 registerForActiveConnectionPropertiesChanged signalHandler = do
-  client <- asks systemDBusClient
+  client <- getSystemDBusClient
   lift $
     DBus.registerForPropertiesChanged
       client
@@ -195,7 +195,7 @@ registerForAccessPointPropertiesChanged ::
   (Signal -> String -> Map String Variant -> [String] -> IO ()) ->
   ReaderT Context IO SignalHandler
 registerForAccessPointPropertiesChanged signalHandler = do
-  client <- asks systemDBusClient
+  client <- getSystemDBusClient
   lift $
     DBus.registerForPropertiesChanged
       client
@@ -240,7 +240,7 @@ getProperties client path iface = runExceptT $ do
         listToMaybe (methodReturnBody reply) >>= fromVariant
 
 getWifiInfo :: TaffyIO WifiInfo
-getWifiInfo = asks systemDBusClient >>= liftIO . getWifiInfoFromClient
+getWifiInfo = getSystemDBusClient >>= liftIO . getWifiInfoFromClient
 
 getWifiInfoFromClient :: Client -> IO WifiInfo
 getWifiInfoFromClient client = do
@@ -373,7 +373,7 @@ updateNetworkInfo chan var = do
     atomically $ writeTChan chan info
 
 getNetworkInfo :: TaffyIO NetworkInfo
-getNetworkInfo = asks systemDBusClient >>= liftIO . getNetworkInfoFromClient
+getNetworkInfo = getSystemDBusClient >>= liftIO . getNetworkInfoFromClient
 
 data ActiveConnectionInfo = ActiveConnectionInfo
   { activeConnectionPath :: ObjectPath,

--- a/src/System/Taffybar/Information/PowerProfiles.hs
+++ b/src/System/Taffybar/Information/PowerProfiles.hs
@@ -127,7 +127,7 @@ getProperties client = runExceptT $ do
 
 -- | Get current power profile info using the system DBus client from Context.
 getPowerProfileInfo :: TaffyIO PowerProfileInfo
-getPowerProfileInfo = asks systemDBusClient >>= liftIO . getPowerProfileInfoFromClient
+getPowerProfileInfo = getSystemDBusClient >>= liftIO . getPowerProfileInfoFromClient
 
 -- | Get current power profile info from a DBus client.
 getPowerProfileInfoFromClient :: Client -> IO PowerProfileInfo
@@ -222,7 +222,7 @@ registerForPowerProfilesPropertiesChanged ::
   (Signal -> String -> Map String Variant -> [String] -> IO ()) ->
   ReaderT Context IO SignalHandler
 registerForPowerProfilesPropertiesChanged signalHandler = do
-  client <- asks systemDBusClient
+  client <- getSystemDBusClient
   lift $
     DBus.registerForPropertiesChanged
       client

--- a/src/System/Taffybar/Information/Systemd.hs
+++ b/src/System/Taffybar/Information/Systemd.hs
@@ -148,8 +148,8 @@ monitorSystemdInfo = do
 
   taffyFork $ do
     ctx <- ask
-    systemClient <- asks systemDBusClient
-    sessionClient <- asks sessionDBusClient
+    systemClient <- getSystemDBusClient
+    sessionClient <- getSessionDBusClient
 
     let doUpdate = updateSystemdInfo chan infoVar systemClient sessionClient
         debouncedUpdate = do
@@ -204,8 +204,8 @@ updateSystemdInfo chan var systemClient sessionClient = do
 -- | Get systemd info using the clients from Context.
 getSystemdInfo :: TaffyIO SystemdInfo
 getSystemdInfo = do
-  systemClient <- asks systemDBusClient
-  sessionClient <- asks sessionDBusClient
+  systemClient <- getSystemDBusClient
+  sessionClient <- getSessionDBusClient
   liftIO $ getSystemdInfoFromClients systemClient sessionClient
 
 -- | Get systemd info from the provided DBus clients.

--- a/src/System/Taffybar/Widget/ASUS.hs
+++ b/src/System/Taffybar/Widget/ASUS.hs
@@ -164,7 +164,7 @@ setupClickHandler ctx ebox = do
           showProfileMenu ctx ebox
           return True
         3 -> do
-          let client = systemDBusClient ctx
+          client <- readSystemDBusClient ctx
           result <- cycleASUSProfile client
           case result of
             Left err ->
@@ -197,7 +197,7 @@ showProfileMenu ctx ebox = do
             else "   "
     item <- Gtk.menuItemNewWithLabel (prefix <> labelText)
     void $ Gtk.onMenuItemActivate item $ do
-      let client = systemDBusClient ctx
+      client <- readSystemDBusClient ctx
       result <- setASUSProfile client profile
       case result of
         Left err ->

--- a/src/System/Taffybar/Widget/MPRIS2.hs
+++ b/src/System/Taffybar/Widget/MPRIS2.hs
@@ -238,7 +238,7 @@ simplePlayerWidget
   Nothing
   np@(Just NowPlaying {npBusName = busName}) = do
     ctx <- ask
-    client <- asks sessionDBusClient
+    client <- getSessionDBusClient
     lift $ do
       mprisLog DEBUG "Building widget for %s" busName
       image <- autoSizeImageNew (loadIconAtSize client busName) Gtk.OrientationHorizontal
@@ -408,7 +408,7 @@ mpris2NewWithControls = mpris2NewWithConfig defaultMPRIS2ControlsConfig
 mpris2NewWithConfig :: MPRIS2Config a -> TaffyIO Gtk.Widget
 mpris2NewWithConfig config =
   ask >>= \ctx ->
-    asks sessionDBusClient >>= \client -> lift $ do
+    getSessionDBusClient >>= \client -> lift $ do
       grid <- Gtk.gridNew
       outerWidget <- Gtk.toWidget grid >>= mprisWidgetWrapper config
       vFillCenter grid

--- a/src/System/Taffybar/Widget/PowerProfiles.hs
+++ b/src/System/Taffybar/Widget/PowerProfiles.hs
@@ -228,7 +228,7 @@ setupClickHandler ctx ebox = do
     if eventType == Gdk.EventTypeButtonPress && button == 1
       then do
         info <- runReaderT getPowerProfileInfoState ctx
-        let client = systemDBusClient ctx
+        client <- readSystemDBusClient ctx
         result <- cycleProfile client info
         case result of
           Left err ->

--- a/src/System/Taffybar/Widget/SNIMenu.hs
+++ b/src/System/Taffybar/Widget/SNIMenu.hs
@@ -16,7 +16,7 @@ import qualified GI.GLib as GLib
 import qualified GI.Gdk as Gdk (EventType (..), getEventButtonButton, getEventButtonType)
 import qualified GI.Gtk as Gtk
 import System.Log.Logger (Priority (..), logM)
-import System.Taffybar.Context (Context (..), TaffyIO)
+import System.Taffybar.Context (TaffyIO, readSessionDBusClient)
 import Text.Printf (printf)
 
 sniMenuLogger :: Priority -> String -> IO ()
@@ -41,7 +41,7 @@ withSniMenu busName menuPath mkWidget = do
           currentEvent <- Gtk.getCurrentEvent
           catchAny
             ( do
-                let client = sessionDBusClient ctx
+                client <- readSessionDBusClient ctx
                 gtkMenu <- DBusMenu.buildMenu client busName menuPath
                 Gtk.menuAttachToWidget gtkMenu ebox Nothing
                 _ <- Gtk.onWidgetHide gtkMenu $

--- a/src/System/Taffybar/Widget/SNITray.hs
+++ b/src/System/Taffybar/Widget/SNITray.hs
@@ -130,7 +130,7 @@ sniTrayNewFromHostParams params =
 -- 'H.Host'.
 sniTrayNewFromHostConfig :: SNITrayConfig -> H.Host -> TaffyIO Gtk.Widget
 sniTrayNewFromHostConfig SNITrayConfig {..} host = do
-  client <- asks sessionDBusClient
+  client <- getSessionDBusClient
   lift $ do
     tray <-
       buildTrayWithPriority
@@ -157,7 +157,7 @@ sniTrayCollapsibleNewFromParams params =
 sniTrayCollapsibleNewFromHostParams ::
   CollapsibleSNITrayParams -> H.Host -> TaffyIO Gtk.Widget
 sniTrayCollapsibleNewFromHostParams CollapsibleSNITrayParams {..} host = do
-  client <- asks sessionDBusClient
+  client <- getSessionDBusClient
   lift $ do
     let SNITrayConfig {..} = collapsibleSNITrayConfig
     tray <-
@@ -278,7 +278,7 @@ sniTrayCollapsibleThatStartsWatcherEvenThoughThisIsABadWayToDoIt =
 getTrayHost :: Bool -> TaffyIO H.Host
 getTrayHost startWatcher = getStateDefault $ do
   pid <- lift getProcessID
-  client <- asks sessionDBusClient
+  client <- getSessionDBusClient
   Just host <-
     lift $
       H.build


### PR DESCRIPTION
## Summary
- add reconnectable DBus client state in `Context` for both session and system buses
- add reconnect monitors that detect disconnects, reconnect, and re-run registered hooks
- switch DBus-heavy modules to fetch the current client at call time via `getSessionDBusClient`/`getSystemDBusClient`
- re-register long-lived DBus exports/hooks (toggle, debug, log server, resume listener) on reconnect
- add a regression test documenting current haskell-dbus behavior across daemon restart

## Testing
- `nix develop -c cabal build lib:taffybar taffybar:testlib`
- `nix develop -c cabal test unit --test-options='--match "dbus-daemon restarts"'`
  - test binary builds, but this host fails at runtime with a local shared-library symbol issue:
    `libpangocairo-1.0.so.0: undefined symbol: FcConfigSetDefaultSubstitute`

Closes #327
