### PR TITLE
Rebase #596: Ensure threads and windows are cleaned up, more unit tests

### DIFF
--- a/src/System/Taffybar/Context.hs
+++ b/src/System/Taffybar/Context.hs
@@ -814,6 +814,7 @@ startX11EventHandler :: Taffy IO ()
 startX11EventHandler = do
   backendType <- asks backend
   when (backendType == BackendX11) $ taffyFork $ do
+    labelMyThread "X11EventLoop"
     c <- ask
     -- XXX: The event loop needs its own X11Context to separately handle
     -- communications from the X server. We deliberately avoid using the context

--- a/src/System/Taffybar/DBus/Toggle.hs
+++ b/src/System/Taffybar/DBus/Toggle.hs
@@ -23,6 +23,7 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Reader (ask, asks)
 import DBus
 import DBus.Client
 import Data.Int

--- a/src/System/Taffybar/DBus/Toggle.hs
+++ b/src/System/Taffybar/DBus/Toggle.hs
@@ -23,7 +23,6 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.Reader
 import DBus
 import DBus.Client
 import Data.Int
@@ -132,7 +131,7 @@ exportTogglesInterface = do
   ctx <- ask
   lift $ taffyStateDir >>= createDirectoryIfMissing True
   stateFile <- lift toggleStateFile
-  let toggleTaffyOnMon fn mon = flip runReaderT ctx $ do
+  let toggleTaffyOnMon fn mon = runTaffy ctx $ do
         lift $ MV.modifyMVar_ enabledVar $ \numToEnabled -> do
           let current = fromMaybe True $ M.lookup mon numToEnabled
               result = M.insert mon (fn current) numToEnabled
@@ -167,7 +166,7 @@ exportTogglesInterface = do
                 autoMethod "showOnMonitor" $
                   takeInt $
                     toggleTaffyOnMon (const True),
-                autoMethod "refresh" $ runReaderT refreshTaffyWindows ctx,
+                autoMethod "refresh" $ runTaffy ctx refreshTaffyWindows,
                 autoMethod "exit" $ exitTaffybar ctx
               ]
           }

--- a/src/System/Taffybar/Information/Battery.hs
+++ b/src/System/Taffybar/Information/Battery.hs
@@ -257,6 +257,7 @@ monitorDisplayBattery propertiesToMonitor = do
   infoVar <- lift $ newMVar $ infoMapToBatteryInfo M.empty
   chan <- liftIO newBroadcastTChanIO
   taffyFork $ do
+    labelMyThread "monitorDisplayBattery"
     ctx <- ask
     let warnOfFailedGetDevice err =
           batteryLogF WARNING "Failure getting DisplayBattery: %s" err

--- a/src/System/Taffybar/Information/Battery.hs
+++ b/src/System/Taffybar/Information/Battery.hs
@@ -32,7 +32,6 @@ import Control.Monad.IO.Class
 import Control.Monad.STM (atomically)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Except
-import Control.Monad.Trans.Reader
 import DBus
 import DBus.Client
 import DBus.Internal.Types (Serial (..))
@@ -270,7 +269,7 @@ monitorDisplayBattery propertiesToMonitor = do
         signalCallback _ _ changedProps _ =
           do
             batteryLogF DEBUG "Battery changed properties: %s" changedProps
-            runReaderT doUpdate ctx
+            runTaffy ctx doUpdate
     _ <- registerForUPowerPropertyChanges propertiesToMonitor signalCallback
     doUpdate
 
@@ -283,8 +282,8 @@ monitorDisplayBattery propertiesToMonitor = do
 refreshBatteriesOnPropChange :: TaffyIO ()
 refreshBatteriesOnPropChange =
   ask >>= \ctx ->
-    let updateIfRealChange _ _ changedProps _ =
-          flip runReaderT ctx
+        let updateIfRealChange _ _ changedProps _ =
+          runTaffy ctx
             $ when
               ( any ((`notElem` ["UpdateTime", "Voltage"]) . fst) $
                   M.toList changedProps

--- a/src/System/Taffybar/Information/ResourceThread.hs
+++ b/src/System/Taffybar/Information/ResourceThread.hs
@@ -1,0 +1,389 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{-|
+Module      : System.Taffybar.Information.ResourceThread
+Description : Mediates access to a non-threadsafe resource
+Copyright   : (c) Rodney Lorrimar, 2024
+License     : BSD3-style (see LICENSE)
+
+Maintainer  : Rodney Lorrimar
+Stability   : unstable
+Portability : GHC
+
+'withResourceThread' mediates access to some resource which must
+not be used concurrently by multiple threads.
+
+For example, "Graphics.X11.Xlib" is not thread-safe, so a
+'Graphics.X11.Xlib.Display' connection must only be used by one
+thread at a time. In this case, we could do:
+
+@
+'withResourceThread' (bracket ('openDisplay' d) 'closeDisplay') $ \\r -> do
+  window <- ...
+  let action = 'mkSafe' $ \\display -> getWMHints display window
+  _ <- forkIO $ do
+    'resourceRunSync' action r
+  'resourceRunSync' action r
+@
+
+In addition to serializing access to the resource,
+'withResourceThread' ensures that all actions involving the resource
+run on the same bound thread. This can help if the resource belongs to
+a C library which uses thread-local state.
+-}
+
+module System.Taffybar.Information.ResourceThread
+  ( withResourceThread
+  , ResourceThread
+  -- * Running requests safely
+  , resourceRunSync
+  , resourceRun
+  , ResourceUnavailableException(..)
+  -- * Building requests
+  , SafeReq(..)
+  , mkSafe
+  -- * Adjusting request execution environment
+  , SafeReqParams(..)
+  , modSafeReq
+  , mkActionModifier
+  , mkCancelHandler
+  , withTimeout
+  , SafeReqTimedOut(..)
+  -- * Escape hatches
+  , unsafeGetResource
+  , resourceThreadCond
+  ) where
+
+import qualified Control.Exception as E
+import Control.Monad
+import Control.Monad.IO.Unlift (MonadIO(..), MonadUnliftIO(..))
+import Control.Concurrent.STM (throwSTM, flushTQueue)
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import GHC.Stack (HasCallStack)
+import System.Log.Logger
+import System.Taffybar.Util (labelMyThread)
+import Text.Printf (printf)
+import UnliftIO.Async (withAsyncBound, Async (..), cancelWith, pollSTM, link)
+import UnliftIO.Concurrent (myThreadId)
+import UnliftIO.Exception (Exception(..), SomeException, SomeAsyncException, evaluate, bracket_, throwIO, withException, fromEitherM, tryAny, isSyncException, trySyncOrAsync, mask, catchSyncOrAsync, finally, catch)
+import UnliftIO.Timeout (timeout)
+import UnliftIO.STM
+
+-- | A handle on the resource thread. Use this with 'resourceRun' or
+-- 'resourceRunSync' on a 'SafeReq' action.
+data ResourceThread x = ResourceThread
+  { async :: Async ()
+    -- ^ Handle on the resource thread which takes requests from the queue.
+  , putRequest :: QueueReq x -> IO ()
+    -- ^ Enqueue a request for execution on the resource thread.
+  , resource :: x
+    -- ^ The protected resource.
+  }
+
+instance Show x => Show (ResourceThread x) where
+  showsPrec d ctx = showParen (d > 10) $
+    showString "ResourceThread { resource = "
+    . showsPrec 11 (resource ctx)
+    . showString ", async = Async { asyncThreadId = "
+    . showsPrec 11 (asyncThreadId (async ctx))
+    . showString " }"
+
+-- | Referential equality of protected resource.
+instance Eq x => Eq (ResourceThread x) where
+  a == b = resource a == resource b
+
+-- | If the resource thread has shut down, or is in the process of
+-- shutting down, then 'SafeReq's can't be run. This exception will be
+-- thrown or returned for all unfinished requests in the queue, and
+-- any new requests.
+data ResourceUnavailableException = ResourceUnavailable
+  deriving (Show, Generic, Typeable)
+instance Exception ResourceUnavailableException
+
+-- | Forks a bound thread for running 'SafeReq's while running the
+-- given action.
+--
+-- A 'ResourceThread' handle is passed to the action.
+withResourceThread
+  :: (HasCallStack, MonadUnliftIO m)
+  => (forall c. (x -> m c) -> m c) -- ^ Resource allocator.
+  -> (ResourceThread x -> m a) -- ^ Action to run.
+  -> m a
+withResourceThread alloc action = do
+  ready <- newEmptyTMVarIO
+  withAsyncBound (resourceThread (putTMVar ready)) (inner (takeTMVar ready))
+  where
+    resourceThread put = do
+      labelMyThread "resourceThread"
+      startResourceQueue alloc put startHandlingRequests
+    inner get a = do
+      link a
+      atomically get >>= action . uncurry (mkResourceThread a)
+
+startResourceQueue
+  :: (HasCallStack, MonadUnliftIO m)
+  => (forall c. (x -> m c) -> m c) -- ^ Resource allocator.
+  -> ((QueueReq x -> STM (), x) -> STM ())
+  -> (x -> m (QueueReq x) -> m a)
+  -> m a
+startResourceQueue withResource ready runQueue = withResource $ \x -> do
+    (getReqSTM, flushSTM) <- atomically $ do
+      requests <- newTQueue
+      ready (writeTQueue requests, x)
+      pure (readTQueue requests, flushTQueue requests)
+    withRunInIO $ \run ->
+      run (runQueue x (atomically getReqSTM))
+      `E.finally` (atomically flushSTM >>= mapM_ abortReq)
+
+mkResourceThread :: Async () -> (QueueReq x -> STM ()) -> x -> ResourceThread x
+mkResourceThread async writeSTM resource = ResourceThread{..}
+  where
+    putRequest req = atomically (putRequestSTM req)
+      `catch` (\ResourceUnavailable -> abortReq req)
+    putRequestSTM req = pollSTM async >>=
+      maybe (writeSTM req) (const $ throwSTM ResourceUnavailable)
+
+------------------------------------------------------------------------
+-- Queued requests
+
+-- | 'SafeReq' invocations are put on the request queue as @'IO' ()@
+-- actions which are passed the resource @x@ as a parameter.
+--
+-- Almost everything which needs to be done for the 'SafeReq'
+-- (e.g. rending back a response) is already baked into the @IO ()@
+-- action by 'doSafeRequest'.
+--
+-- The resource may be 'Nothing', which means that the resource thread
+-- is shutting down and so the request should be aborted.
+type QueueReq x = Maybe x -> IO ()
+
+-- | The loop which runs 'IO' actions taken from the queue.
+startHandlingRequests :: MonadUnliftIO m => x -> m (QueueReq x) -> m a -- ^ Never returns.
+startHandlingRequests r getRequest = logAround INFO "startHandlingRequests" $ do
+  labelMyThread "resourceRequestThread"
+  forever (liftIO . ($ Just r) =<< getRequest)
+
+-- | Returns a 'ResourceUnavailableException' to the callback of the
+-- given 'QueueReq'.
+abortReq :: MonadIO m => QueueReq x -> m ()
+abortReq = liftIO . ($ Nothing)
+
+------------------------------------------------------------------------
+
+-- | Represents 'IO' actions which use the resource and so must
+-- be queued and run sequentially using 'resourceRun' or 'resourceRunSync'.
+data SafeReq x r = SafeReq
+  { safeReqParams :: SafeReqParams x
+  , safeReq :: x -> IO r
+  }
+
+instance Functor (SafeReq x) where
+  fmap f s = s { safeReq = fmap f . safeReq s }
+
+instance Applicative (SafeReq x) where
+  pure = SafeReq mempty . const . pure
+  f <*> s = s { safeReq = \d -> doSafeRequest f d <*> doSafeRequest s d }
+
+instance Monad (SafeReq x) where
+  a >>= f = a { safeReq = \d -> safeReq a d >>= flip doSafeRequest d . f }
+
+instance MonadIO (SafeReq x) where
+  liftIO = SafeReq mempty . const
+
+instance MonadUnliftIO (SafeReq x) where
+  withRunInIO inner = SafeReq mempty $ \dpy ->
+    withRunInIO $ \run ->
+    inner (run . flip safeReq dpy)
+
+-- | Construct a 'SafeReq' with default parameters.
+mkSafe
+  :: (x -> IO r) -- ^ 'IO' action which uses the resource @x@.
+  -> SafeReq x r -- ^ A 'SafeReq' with default parameters.
+mkSafe = SafeReq mempty
+
+-- | Adjusts 'safeReqParams' of a 'SafeReq' using the given function.
+modSafeReq :: (SafeReqParams x -> SafeReqParams x) -> SafeReq x r -> SafeReq x r
+modSafeReq f s = s { safeReqParams = f (safeReqParams s) }
+
+-- | 'SafeReqParams' modify the execution environment of a 'SafeReq'.
+--
+-- 'mempty' represents the default 'SafeReqParams'. The defaults are
+-- no 'actionModifier' and a 'cancelHandler' which uses 'cancelWith'.
+--
+-- They can be combined with @'(<>)'@. When combining 'SafeReqParams'
+-- with @p <> q@, the @'actionModifier' q@ runs first (inside of
+-- @'actionModifier' p@), and @'cancelHandler' p@ runs before
+-- @'cancelHandler' q@.
+data SafeReqParams x = SafeReqParams
+  { actionModifier :: forall a. x -> IO a -> IO a
+  , cancelHandler :: Async () -> SomeAsyncException -> IO ()
+  }
+
+instance Semigroup (SafeReqParams x) where
+  SafeReqParams f h1 <> SafeReqParams g h2 =
+    SafeReqParams (\x -> f x . g x) (\e -> h1 e >> h2 e)
+
+instance Monoid (SafeReqParams x) where
+  mempty = SafeReqParams (const id) logCancelWith
+
+logCancelWith :: Async () -> SomeAsyncException  -> IO ()
+logCancelWith a e = logAround WARNING ("Default cancelWith handler for " ++ show e)
+  (cancelWith a e)
+
+mkActionModifier :: (forall a. x -> IO a -> IO a) -> SafeReqParams x
+mkActionModifier f = mempty { actionModifier = f }
+
+mkCancelHandler :: (Async () -> SomeAsyncException -> IO ()) -> SafeReqParams x
+mkCancelHandler f = mempty { cancelHandler = f }
+
+------------------------------------------------------------------------
+
+doSafeRequestFull
+  :: HasCallStack
+  => (Either SomeException a -> IO ()) -- ^ Result callback.
+  -> SafeReq x a -- ^ Action which uses the resource @x@
+  -> QueueReq x -- ^ A simple 'IO ()' to put on the queue.
+doSafeRequestFull callback action = callback <=< doReq
+  where
+    doReq = trySyncOrAsync . useResource (doSafeRequest action)
+    useResource = maybe (throwIO ResourceUnavailable)
+
+-- | Converts a @'SafeReq' x r@ to an @'IO' r@.
+doSafeRequest :: HasCallStack => SafeReq x r -> x -> IO r
+doSafeRequest action x = logErrors . modifier . doRequest $ action
+  where
+    doRequest = evaluate <=< flip safeReq x
+    modifier = actionModifier (safeReqParams action) x
+
+    enableLogging = True
+    logErrors = if enableLogging then flip withException logError else id
+    logError :: SomeException -> IO ()
+    logError e = when (isSyncException e) $
+      pure ()
+      -- logHere WARNING $ printf "Handling X11 error: %s\n%s"
+      -- (displayException e) (prettyCallStack callStack)
+
+-- | Compare the current thread's ID with that of the designated
+-- resource thread. It returns the:
+--
+--  * the __first__ value if we are running in __some other thread__.
+--  * the __second__ value if we are running in __the resource thread__.
+resourceThreadCond
+  :: (HasCallStack, MonadUnliftIO m)
+  => a -- ^ Running on some other thread.
+  -> a -- ^ Running on designated resource thread.
+  -> ResourceThread x -- ^ Belongs to designated resource thread.
+  -> m a
+resourceThreadCond isn't itIs r = do
+  currentTID <- myThreadId
+  let resourceThread = asyncThreadId (async r)
+  pure $ if currentTID == resourceThread then itIs else isn't
+
+-- | Post the provided 'SafeReq' action to a 'ResourceThread', and
+-- return immediately. The given callback is passed a result upon
+-- completion.
+resourceRun
+  :: HasCallStack
+  => SafeReq x a -- ^ Action which uses the resource @x@.
+  -> (Either SomeException a -> IO ()) -- ^ Result callback.
+  -> ResourceThread x -- ^ Context in which 'SafeReq' action will be run.
+  -> IO () -- ^ Returns immediately
+resourceRun action callback ctx = do
+  run <- resourceThreadCond later now ctx
+  liftIO $ run (doSafeRequestFull callback action)
+  where
+    later = putRequest ctx
+    now f = f (Just (resource ctx))
+
+-- | Post the provided 'SafeReq' action to the dedicated resource
+-- thread, and wait for the result.
+--
+-- Any exception caught while running the action will be rethrown here.
+--
+-- Any asyncronous exception received while waiting for the result
+-- will be re-thrown into the dedicated resource thread. This will
+-- block until the resource thread has exited. We don't want the
+-- resource thread lingering vexatiously while other cleanup handlers
+-- are running.
+resourceRunSync :: HasCallStack => SafeReq x a -> ResourceThread x -> IO a
+resourceRunSync action ctx = do
+  var <- newEmptyTMVarIO
+
+  -- Send the action to the resource thread. The completion callback
+  -- will fill the MVar.
+  fromEitherM $ mask $ \restore -> do
+    resourceRun action (atomically . putTMVar var) ctx
+
+    -- Block waiting for resourceRun to run the callback.
+    -- We restore the mask to allow cancelling by async exceptions
+    -- (although waiting for an empty MVar can always be interrupted).
+    restore (atomically $ takeTMVar var)
+      `catchSyncOrAsync`
+      (restore . runCancelHandler (safeReqParams action) ctx)
+
+-- | An asynchronous exception is received while waiting for the
+-- callback.
+--
+-- Pass the exception to the 'cancelHandler', along with the
+-- resource thread 'Async' handle. This allows the caller to
+-- make sure the 'SafeReq' action is properly stopped, before
+-- unblocking.
+--
+-- Any exception encountered while running 'cancelHandler' is ignored,
+-- in favour of the first exception received.
+runCancelHandler :: HasCallStack => SafeReqParams x -> ResourceThread x -> SomeAsyncException -> IO a
+runCancelHandler params ctx e = do
+  logHere NOTICE $ "Caught async exception while waiting for result of SafeReq: " ++ show e
+  logAround NOTICE "Running cancelHandler" $
+    -- This will usually block until thread exits
+    void $ tryAny $ cancelHandler params (async ctx) e
+  logHere DEBUG "Cancel finished, rethrowing the async exception"
+  throwIO e
+
+-- | Use this if you need access to the allocated resource outside of 'resourceRun'.
+unsafeGetResource :: ResourceThread x -> x
+unsafeGetResource = resource
+
+------------------------------------------------------------------------
+
+-- | This can be added to 'SafeReqParams' set a timeout for the
+-- action.
+--
+-- Warnings:
+--
+--   1. Foreign function calls usually can't be interrupted by an
+--   asynchronous exception. If they have an @interruptible@
+--   annotation, then interruption /might/ be possible, depending on
+--   specific implementation details of the foreign function.
+--
+--   2. After cancelling an operation, the resource may be left in a
+--   state where it is unable to immediately run the next queued
+--   action. This also depends on specific implementation details.
+withTimeout
+  :: Int -- ^ Interval in microseconds.
+  -> SafeReqParams x
+withTimeout t = mempty { actionModifier = const $ throwTimeout t }
+
+throwTimeout :: MonadUnliftIO m => Int -> m a -> m a
+throwTimeout t = maybe (throwIO (SafeReqTimedOut t)) pure <=< timeout t
+
+-- | An 'Exception' which is thrown if the 'withTimeout' interval is reached.
+newtype SafeReqTimedOut = SafeReqTimedOut { requestTimeoutUsec :: Int }
+  deriving (Show, Read, Eq, Typeable, Generic)
+
+instance Exception SafeReqTimedOut where
+  displayException (SafeReqTimedOut t) = printf "call timed out after %dusec" t
+
+------------------------------------------------------------------------
+
+logHere :: MonadIO m => Priority -> String -> m ()
+logHere p = liftIO . logM "System.Taffybar.Information.ResourceThread" p
+
+logAround :: MonadUnliftIO m => Priority -> String -> m a -> m a
+logAround p msg = bracket_ (logHere p (msg ++ "...")) (logHere p ("..." ++ msg))

--- a/src/System/Taffybar/Information/SafeX11.hs
+++ b/src/System/Taffybar/Information/SafeX11.hs
@@ -54,6 +54,7 @@ import Graphics.X11.Xlib.Extras hiding
   )
 import System.IO.Unsafe
 import System.Log.Logger
+import System.Taffybar.Util (labelMyThread)
 import System.Timeout
 import Text.Printf
 
@@ -133,7 +134,9 @@ requestQueue = unsafePerformIO newChan
 
 {-# NOINLINE x11Thread #-}
 x11Thread :: ThreadId
-x11Thread = unsafePerformIO $ forkIO startHandlingX11Requests
+x11Thread = unsafePerformIO $ forkIO $ do
+  labelMyThread "x11Thread"
+  startHandlingX11Requests
 
 withErrorHandler :: XErrorHandler -> IO a -> IO a
 withErrorHandler new_handler action = do

--- a/src/System/Taffybar/SimpleConfig.hs
+++ b/src/System/Taffybar/SimpleConfig.hs
@@ -34,8 +34,7 @@ module System.Taffybar.SimpleConfig
 where
 
 import qualified Control.Concurrent.MVar as MV
-import Control.Monad
-import Control.Monad.Trans.Class
+import Control.Monad.Trans.Class (lift)
 import Data.Default (Default (..))
 import Data.List
 import Data.Maybe
@@ -205,20 +204,17 @@ simpleDyreTaffybar conf = dyreTaffybar $ toTaffybarConfig conf
 simpleTaffybar :: SimpleTaffyConfig -> IO ()
 simpleTaffybar conf = startTaffybar $ toTaffybarConfig conf
 
-getMonitorCount :: IO Int
-getMonitorCount =
-  fromIntegral
-    <$> ( screenGetDefault
-            >>= maybe
-              (return 0)
-              (screenGetDisplay >=> displayGetNMonitors)
-        )
+-- | Get the number of monitors that belong to the default display.
+-- If the GDK display manager has no default display, this will return
+-- 'Nothing'.
+getMonitorCount :: IO (Maybe Int)
+getMonitorCount = displayGetDefault >>= mapM (fmap fromIntegral . displayGetNMonitors)
 
 -- | Supply this value for 'monitorsAction' to display the taffybar window on
 -- all monitors.
 useAllMonitors :: TaffyIO [Int]
 useAllMonitors = lift $ do
-  count <- getMonitorCount
+  count <- fromMaybe 1 <$> getMonitorCount
   return [0 .. count - 1]
 
 -- | Supply this value for 'monitorsAction' to display the taffybar window only

--- a/src/System/Taffybar/Util.hs
+++ b/src/System/Taffybar/Util.hs
@@ -56,6 +56,7 @@ module System.Taffybar.Util
     onSigINT,
     maybeHandleSigHUP,
     handlePosixSignal,
+    labelMyThread,
 
     -- * Resource management
     rebracket,
@@ -89,6 +90,9 @@ import Data.Maybe
 import qualified Data.Text as T
 import qualified Data.Time.Clock as Clock
 import Data.Tuple.Sequence
+#if MIN_VERSION_base(4,18,0)
+import GHC.Conc.Sync (labelThread, myThreadId)
+#endif
 import qualified GI.GLib.Constants as G
 import qualified GI.GdkPixbuf.Objects.Pixbuf as Gdk
 import Network.HTTP.Simple
@@ -419,3 +423,11 @@ withSigHandlerBase :: Signal -> Handler -> IO a -> IO a
 withSigHandlerBase sig h = bracket (install h) install . const
   where
     install handler = installHandler sig handler Nothing
+
+-- | Assigns a descriptive name to the currently running thread.
+labelMyThread :: MonadIO m => String -> m ()
+#if MIN_VERSION_base(4,18,0)
+labelMyThread name = liftIO (myThreadId >>= flip labelThread name)
+#else
+labelMyThread _ = pure ()
+#endif

--- a/src/System/Taffybar/Widget/Battery.hs
+++ b/src/System/Taffybar/Widget/Battery.hs
@@ -31,7 +31,6 @@ where
 
 import Control.Monad
 import Control.Monad.IO.Class
-import Control.Monad.Trans.Reader
 import Data.Default (Default (..))
 import Data.GI.Base.Overloading (IsDescendantOf)
 import Data.IORef (newIORef, readIORef, writeIORef)
@@ -165,10 +164,10 @@ textBatteryNewWithLabelAction labelSetter = do
   liftIO $ do
     label <- labelNew Nothing
     let updateWidget =
-          postGUIASync . flip runReaderT ctx . labelSetter label
+          postGUIASync . runTaffy ctx . labelSetter label
     void $
       onWidgetRealize label $
-        runReaderT getDisplayBatteryInfo ctx >>= updateWidget
+        runTaffy ctx getDisplayBatteryInfo >>= updateWidget
     toWidget =<< channelWidgetNew label chan updateWidget
 
 themeLoadFlags :: [IconLookupFlags]
@@ -184,7 +183,7 @@ batteryIconNew = do
   let setIconForSize size = do
         iw <- readIORef imageWidgetRef
         styleCtx <- widgetGetStyleContext iw
-        name <- T.pack . batteryIconName <$> runReaderT getDisplayBatteryInfo ctx
+        name <- T.pack . batteryIconName <$> runTaffy ctx getDisplayBatteryInfo
         iconThemeLookupIcon defaultTheme name size themeLoadFlags
           >>= traverse (\info -> fst <$> iconInfoLoadSymbolicForContext info styleCtx)
   (imageWidget, updateImage) <- scalingImage setIconForSize OrientationHorizontal

--- a/src/System/Taffybar/Widget/Battery.hs
+++ b/src/System/Taffybar/Widget/Battery.hs
@@ -31,6 +31,7 @@ where
 
 import Control.Monad
 import Control.Monad.IO.Class
+import Control.Monad.Trans.Reader (ask)
 import Data.Default (Default (..))
 import Data.GI.Base.Overloading (IsDescendantOf)
 import Data.IORef (newIORef, readIORef, writeIORef)

--- a/src/System/Taffybar/Widget/Crypto.hs
+++ b/src/System/Taffybar/Widget/Crypto.hs
@@ -26,6 +26,7 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Reader (ask)
 import Data.Aeson
 import qualified Data.Aeson.Key as Key
 import Data.Aeson.Types
@@ -65,7 +66,8 @@ cryptoPriceLabelWithIcon = do
   ctx <- ask
   let refresh size =
         Just
-          <$> runTaffy ctx
+          <$> runTaffy
+            ctx
             (fromMaybe <$> pixBufFromColor size 0 <*> getCryptoPixbuf symbol)
   (image, _) <- scalingImage refresh Gtk.OrientationHorizontal
   _ <- widgetSetClassGI image "crypto-price-icon"

--- a/src/System/Taffybar/Widget/Crypto.hs
+++ b/src/System/Taffybar/Widget/Crypto.hs
@@ -26,7 +26,6 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.Reader
 import Data.Aeson
 import qualified Data.Aeson.Key as Key
 import Data.Aeson.Types
@@ -66,9 +65,8 @@ cryptoPriceLabelWithIcon = do
   ctx <- ask
   let refresh size =
         Just
-          <$> runReaderT
+          <$> runTaffy ctx
             (fromMaybe <$> pixBufFromColor size 0 <*> getCryptoPixbuf symbol)
-            ctx
   (image, _) <- scalingImage refresh Gtk.OrientationHorizontal
   _ <- widgetSetClassGI image "crypto-price-icon"
   _ <- widgetSetClassGI label "crypto-price-label"

--- a/src/System/Taffybar/Widget/Layout.hs
+++ b/src/System/Taffybar/Widget/Layout.hs
@@ -83,7 +83,7 @@ layoutNew config = do
   -- This callback is run in a separate thread and needs to use
   -- postGUIASync
   let callback _ = mapReaderT postGUIASync $ do
-        layout <- runX11Def "" $ readAsString Nothing xLayoutProp
+        layout <- runProperty $ readAsString xLayoutProp Nothing
         markup <- formatLayout config (T.pack layout)
         lift $ Gtk.labelSetMarkup label markup
 
@@ -104,7 +104,7 @@ dispatchButtonEvent context btn = do
   ev <- isLR <$> getEventButtonType btn <*> getEventButtonButton btn
   case ev of
     Just inc -> do
-      runTaffy context (runX11Def () (switch inc))
+      runPropContext context (switch inc)
       return True
     Nothing -> return False
   where

--- a/src/System/Taffybar/Widget/Layout.hs
+++ b/src/System/Taffybar/Widget/Layout.hs
@@ -27,6 +27,7 @@ module System.Taffybar.Widget.Layout
 where
 
 import Control.Monad.Trans.Class
+import Control.Monad.Trans.Reader (ask, mapReaderT)
 import Data.Default (Default (..))
 import qualified Data.Text as T
 import GI.Gdk
@@ -83,7 +84,7 @@ layoutNew config = do
   -- This callback is run in a separate thread and needs to use
   -- postGUIASync
   let callback _ = mapReaderT postGUIASync $ do
-        layout <- runProperty $ readAsString xLayoutProp Nothing
+        layout <- runX11Def "" $ readAsString Nothing xLayoutProp
         markup <- formatLayout config (T.pack layout)
         lift $ Gtk.labelSetMarkup label markup
 
@@ -104,7 +105,7 @@ dispatchButtonEvent context btn = do
   ev <- isLR <$> getEventButtonType btn <*> getEventButtonButton btn
   case ev of
     Just inc -> do
-      runPropContext context (switch inc)
+      runTaffy context (runX11Def () (switch inc))
       return True
     Nothing -> return False
   where

--- a/src/System/Taffybar/Widget/Layout.hs
+++ b/src/System/Taffybar/Widget/Layout.hs
@@ -27,7 +27,6 @@ module System.Taffybar.Widget.Layout
 where
 
 import Control.Monad.Trans.Class
-import Control.Monad.Trans.Reader
 import Data.Default (Default (..))
 import qualified Data.Text as T
 import GI.Gdk
@@ -95,22 +94,25 @@ layoutNew config = do
     Gtk.containerAdd ebox label
     _ <- Gtk.onWidgetButtonPressEvent ebox $ dispatchButtonEvent ctx
     Gtk.widgetShowAll ebox
-    _ <- Gtk.onWidgetUnrealize ebox $ flip runReaderT ctx $ unsubscribe subscription
+    _ <- Gtk.onWidgetUnrealize ebox $ runTaffy ctx $ unsubscribe subscription
     Gtk.toWidget ebox
 
 -- | Call 'switch' with the appropriate argument (1 for left click, -1 for
 -- right click), depending on the click event received.
 dispatchButtonEvent :: Context -> EventButton -> IO Bool
 dispatchButtonEvent context btn = do
-  pressType <- getEventButtonType btn
-  buttonNumber <- getEventButtonButton btn
-  case pressType of
-    EventTypeButtonPress ->
-      case buttonNumber of
-        1 -> runReaderT (runX11Def () (switch 1)) context >> return True
-        2 -> runReaderT (runX11Def () (switch (-1))) context >> return True
-        _ -> return False
-    _ -> return False
+  ev <- isLR <$> getEventButtonType btn <*> getEventButtonButton btn
+  case ev of
+    Just inc -> do
+      runTaffy context (runX11Def () (switch inc))
+      return True
+    Nothing -> return False
+  where
+    isLR EventTypeButtonPress buttonNumber = case buttonNumber of
+      1 -> Just 1
+      2 -> Just (-1)
+      _ -> Nothing
+    isLR _ _ = Nothing
 
 -- | Emit a new custom event of type _XMONAD_CURRENT_LAYOUT, that can be
 -- intercepted by the PagerHints hook, which in turn can instruct XMonad to

--- a/src/System/Taffybar/Widget/MPRIS2.hs
+++ b/src/System/Taffybar/Widget/MPRIS2.hs
@@ -26,7 +26,6 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Except
-import Control.Monad.Trans.Reader
 import DBus
 import DBus.Client
 import qualified DBus.TH as DBus
@@ -270,7 +269,7 @@ simplePlayerWidget
       widget <- Gtk.toWidget ebox
       let widgetData =
             MPRIS2PlayerWidget {playerLabel = label, playerWidget = widget}
-      flip runReaderT ctx $
+      runTaffy ctx $
         simplePlayerWidget c addToParent (Just widgetData) np
 simplePlayerWidget
   config
@@ -376,7 +375,7 @@ simplePlayerWidgetWithControls
                 controlsPlayPauseButtonLabel = playPauseButtonLabel,
                 controlsNextButton = nextButton
               }
-      flip runReaderT ctx $
+      runTaffy ctx $
         simplePlayerWidgetWithControls c addToParent (Just widgetData) np
 simplePlayerWidgetWithControls
   config
@@ -448,7 +447,7 @@ mpris2NewWithConfig config =
           updatePlayerWidgetsVar nowPlayings =
             postGUISync $
               MV.modifyMVar_ playerWidgetsVar $
-                flip runReaderT ctx
+                runTaffy ctx
                   . updatePlayerWidgets nowPlayings
 
           setPlayingClass = do

--- a/src/System/Taffybar/Widget/MPRIS2.hs
+++ b/src/System/Taffybar/Widget/MPRIS2.hs
@@ -26,6 +26,7 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Except
+import Control.Monad.Trans.Reader (ask, asks)
 import DBus
 import DBus.Client
 import qualified DBus.TH as DBus

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -384,6 +384,7 @@ test-suite unit
                , hspec
                , hspec-core
                , hspec-golden
+               , managed
                , taffybar
                , taffybar:testlib
                , typed-process

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -391,6 +391,7 @@ test-suite unit
                , unliftio
                , transformers
                , QuickCheck
+               , X11
   build-tool-depends: hspec-discover:hspec-discover == 2.*
                    , taffybar:taffybar-test-wm
                    , taffybar:taffybar-appearance-snap

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -76,6 +76,7 @@ library
                , filepath
                , fsnotify >= 0.4 && < 0.5
                , monad-control
+               , monad-unlift
                , gi-cairo-connector
                , gi-cairo-render
                 , gi-gdk3 >=3.0.30 && <3.1
@@ -113,6 +114,8 @@ library
                , transformers >= 0.3.0.0
                , tuple >= 0.3.0.2
                , unix
+               , unliftio
+               , unliftio-core
                , utf8-string
                , xdg-desktop-entry
                , xdg-basedir >= 0.2 && < 0.3
@@ -156,6 +159,7 @@ library
                  , System.Taffybar.Information.NetworkManager
                  , System.Taffybar.Information.PowerProfiles
                  , System.Taffybar.Information.Privacy
+                 , System.Taffybar.Information.ResourceThread
                  , System.Taffybar.Information.ScreenLock
                  , System.Taffybar.Information.SafeX11
                  , System.Taffybar.Information.Systemd
@@ -369,12 +373,14 @@ test-suite unit
                , System.Taffybar.AppearanceSpec
                , System.Taffybar.ContextSpec
                , System.Taffybar.Information.CryptoSpec
+               , System.Taffybar.Information.ResourceThreadSpec
                , System.Taffybar.Information.X11DesktopInfoSpec
                , System.Taffybar.Information.WakeupSpec
                , System.Taffybar.SimpleConfigSpec
                , System.Taffybar.Widget.Workspaces.ChannelSpec
                , System.Taffybar.Widget.WindowsSpec
-  build-depends: data-default
+  build-depends: containers
+               , data-default
                , bytestring
                , directory
                , JuicyPixels
@@ -385,6 +391,7 @@ test-suite unit
                , hspec-core
                , hspec-golden
                , managed
+               , stm
                , taffybar
                , taffybar:testlib
                , typed-process
@@ -393,6 +400,7 @@ test-suite unit
                , transformers
                , QuickCheck
                , X11
+               , quickcheck-state-machine
   build-tool-depends: hspec-discover:hspec-discover == 2.*
                    , taffybar:taffybar-test-wm
                    , taffybar:taffybar-appearance-snap

--- a/test/unit/System/Taffybar/ContextSpec.hs
+++ b/test/unit/System/Taffybar/ContextSpec.hs
@@ -6,27 +6,28 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module System.Taffybar.ContextSpec
-  ( spec,
+  ( spec
 
     -- * Utils
-    runTaffyDefault,
+  , runTaffyDefault
 
     -- * Abstract Config
-    GenSimpleConfig (..),
-    toSimpleConfig,
-    GenWidget (..),
-    toTaffyWidget,
-    GenSpace (..),
-    GenCssPath (..),
-    toCssPaths,
-    GenMonitorsAction (..),
-    toMonitorsAction,
-  )
-where
+  , GenSimpleConfig (..)
+  , toSimpleConfig
+  , GenWidget (..)
+  , toTaffyWidget
+  , GenSpace (..)
+  , GenCssPath (..)
+  , toCssPaths
+  , GenMonitorsAction (..)
+  , toMonitorsAction
+  ) where
 
 import Control.Exception (SomeException, catch)
-import Control.Monad.Trans.Reader (runReaderT)
+import Control.Monad (when)
+import Control.Monad.Managed
 import Data.Default (def)
+import Data.List ((\\))
 import Data.Ratio ((%))
 import GHC.Generics (Generic)
 import GI.Gtk (Widget)
@@ -35,7 +36,7 @@ import System.FilePath ((</>))
 import System.Taffybar.Context
 import System.Taffybar.SimpleConfig
 import System.Taffybar.Test.DBusSpec (withTestDBus)
-import System.Taffybar.Test.UtilSpec (logSetup, withSetEnv)
+import System.Taffybar.Test.UtilSpec (diffLiveThreads, laxTimeout', listFds, listLiveThreads, logSetup, withSetEnv)
 import System.Taffybar.Test.XvfbSpec (setDefaultDisplay_, withXdummy)
 import System.Taffybar.Widget.SimpleClock (textClockNewWith)
 import System.Taffybar.Widget.Workspaces (workspacesNew)
@@ -54,9 +55,9 @@ spec = logSetup $ sequential $ aroundAll_ withTestDBus $ aroundAll_ (withXdummy 
       removePathForcibly runtime `catch` (\(_ :: SomeException) -> pure ())
       createDirectoryIfMissing True runtime
       withSetEnv
-        [ ("XDG_RUNTIME_DIR", runtime),
-          ("WAYLAND_DISPLAY", wl),
-          ("XDG_SESSION_TYPE", "wayland")
+        [ ("XDG_RUNTIME_DIR", runtime)
+        , ("WAYLAND_DISPLAY", wl)
+        , ("XDG_SESSION_TYPE", "wayland")
         ]
         $ do
           detectBackend `shouldReturn` BackendX11
@@ -71,37 +72,60 @@ spec = logSetup $ sequential $ aroundAll_ withTestDBus $ aroundAll_ (withXdummy 
       createDirectoryIfMissing True runtime
       writeFile wlPath "" -- exists but is not a socket
       withSetEnv
-        [ ("XDG_RUNTIME_DIR", runtime),
-          ("WAYLAND_DISPLAY", wl),
-          ("XDG_SESSION_TYPE", "wayland")
+        [ ("XDG_RUNTIME_DIR", runtime)
+        , ("WAYLAND_DISPLAY", wl)
+        , ("XDG_SESSION_TYPE", "wayland")
         ]
         $ do
           detectBackend `shouldReturn` BackendX11
       removePathForcibly runtime `catch` (\(_ :: SomeException) -> pure ())
 
+  describe "Resource cleanup" $ do
+    it "cleanup happens within a short time" $ example $ do
+      laxTimeout' 1_000_000 $ with (buildContext def) $ const $ pure ()
+
+    it "should not leak file descriptors, e.g. X11 connections" $ example $ do
+      fdsBefore <- listFds
+      fdsDuring <- laxTimeout' 1_000_000 $ with (buildContext def) $ const listFds
+      length fdsDuring `shouldSatisfy` (> length fdsBefore)
+      fdsAfter <- listFds
+
+      fdsAfter \\ fdsBefore `shouldBe` []
+
+    it "should not leak threads" $ example $ do
+      threadsBefore <- listLiveThreads
+      when (null threadsBefore) $ pendingWith "GHC version doesn't have listThreads"
+      threadsDuring <- laxTimeout' 1_000_000 $ with (buildContext def) $ const listLiveThreads
+      length threadsDuring `shouldSatisfy` (> length threadsBefore)
+
+      threadsAfter <- listLiveThreads
+
+      diffLiveThreads threadsAfter threadsBefore `shouldBe` []
+
   describe "Fuzz tests" $ do
+    prop "too trivial" prop_context_too_trivial
     prop "eval generators" prop_genSimpleConfig
-    xprop "TaffybarConfig" prop_taffybarConfig
+    prop "TaffybarConfig" prop_taffybarConfig
 
 ------------------------------------------------------------------------
 
 runTaffyDefault :: TaffyIO a -> IO a
-runTaffyDefault f = buildContext def >>= runReaderT f
+runTaffyDefault f = with (buildContext def) $ \ctx -> runTaffy ctx f
 
 ------------------------------------------------------------------------
 
 -- | Represents 'SimpleTaffyConfig' in a more abstract way, so that
 -- it's easier to 'show', 'shrink', 'assert', etc.
 data GenSimpleConfig = GenSimpleConfig
-  { monitors :: GenMonitorsAction,
-    size :: StrutSize,
-    padding :: GenSpace,
-    position :: Position,
-    spacing :: GenSpace,
-    start :: [GenWidget],
-    center :: [GenWidget],
-    end :: [GenWidget],
-    css :: [GenCssPath]
+  { monitors :: GenMonitorsAction
+  , size :: StrutSize
+  , padding :: GenSpace
+  , position :: Position
+  , spacing :: GenSpace
+  , start :: [GenWidget]
+  , center :: [GenWidget]
+  , end :: [GenWidget]
+  , css :: [GenCssPath]
   }
   deriving (Show, Eq, Generic)
 
@@ -109,17 +133,17 @@ data GenSimpleConfig = GenSimpleConfig
 toSimpleConfig :: GenSimpleConfig -> SimpleTaffyConfig
 toSimpleConfig GenSimpleConfig {..} =
   SimpleTaffyConfig
-    { monitorsAction = toMonitorsAction monitors,
-      barHeight = size,
-      barPadding = unGenSpace padding,
-      barPosition = position,
-      widgetSpacing = unGenSpace spacing,
-      startWidgets = map toTaffyWidget start,
-      centerWidgets = map toTaffyWidget center,
-      endWidgets = map toTaffyWidget end,
-      barLevels = Nothing,
-      cssPaths = toCssPaths css,
-      startupHook = pure () -- TODO: add something
+    { monitorsAction = toMonitorsAction monitors
+    , barHeight = size
+    , barPadding = unGenSpace padding
+    , barPosition = position
+    , widgetSpacing = unGenSpace spacing
+    , startWidgets = map toTaffyWidget start
+    , centerWidgets = map toTaffyWidget center
+    , endWidgets = map toTaffyWidget end
+    , barLevels = Nothing
+    , cssPaths = toCssPaths css
+    , startupHook = pure () -- TODO: add something
     }
 
 toTaffyWidget :: GenWidget -> TaffyIO Widget
@@ -143,8 +167,8 @@ instance Arbitrary GenSimpleConfig where
 instance Arbitrary StrutSize where
   arbitrary =
     oneof
-      [ ExactSize . getSmall . getPositive <$> arbitrary,
-        ScreenRatio <$> elements [1 % 27, 1 % 50, 1 % 2] -- TODO: more arbitrary
+      [ ExactSize . getSmall . getPositive <$> arbitrary
+      , ScreenRatio <$> elements [1 % 27, 1 % 50, 1 % 2] -- TODO: more arbitrary
       ]
   shrink (ExactSize s) = ExactSize . getPositive <$> shrink (Positive (fromIntegral s))
   shrink (ScreenRatio r) = ScreenRatio <$> shrink r
@@ -184,9 +208,9 @@ data GenMonitorsAction
 instance Arbitrary GenMonitorsAction where
   arbitrary =
     oneof
-      [ pure UsePrimaryMonitor,
-        pure UseAllMonitors,
-        wild
+      [ pure UsePrimaryMonitor
+      , pure UseAllMonitors
+      , wild
       ]
     where
       -- This could be a lot meaner.
@@ -203,18 +227,22 @@ prop_genSimpleConfig cfg =
     cover 25 (monitors cfg == UsePrimaryMonitor) "Primary monitor only" $
       cfg === cfg
 
-prop_taffybarConfig :: GenSimpleConfig -> Property
-prop_taffybarConfig cfg =
-  within 1_000_000 $
-    monadicIO $
-      pure (cfg =/= cfg)
+prop_context_too_trivial :: Property
+prop_context_too_trivial = withMaxSuccess 50 $ monadicIO $
+  run $ runTaffyDefault (pure ())
 
--- Some possible assertions:
---   startupHook executed exactly once
---   css rules are applied
---   css files later in list have precedence
---   missing css => exception
---   error in css => warning and continue
---   widgets are visible
---   spacing/height/position/padding are observed
---   appears on the correct monitor
+prop_taffybarConfig :: GenSimpleConfig -> Property
+prop_taffybarConfig cfg = within 1_000_000 $ monadicIO $ do
+  let cfg' = toTaffybarConfig (toSimpleConfig cfg)
+  a <- run $ with (buildContext cfg') $ \_context -> do
+    pure True
+  assert a
+  -- Some possible assertions:
+  --   startupHook executed exactly once
+  --   css rules are applied
+  --   css files later in list have precedence
+  --   missing css => exception
+  --   error in css => warning and continue
+  --   widgets are visible
+  --   spacing/height/position/padding are observed
+  --   appears on the correct monitor

--- a/test/unit/System/Taffybar/Information/ResourceThreadSpec.hs
+++ b/test/unit/System/Taffybar/Information/ResourceThreadSpec.hs
@@ -1,0 +1,471 @@
+{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE DerivingVia            #-}
+{-# LANGUAGE DeriveFoldable            #-}
+{-# LANGUAGE DeriveFunctor             #-}
+{-# LANGUAGE DeriveGeneric             #-}
+{-# LANGUAGE DeriveTraversable         #-}
+{-# LANGUAGE DerivingStrategies        #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE TypeOperators             #-}
+{-# LANGUAGE UndecidableInstances      #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+
+{-# OPTIONS_GHC -Wno-orphans -Wno-unused-binds -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Unused LANGUAGE pragma" #-}
+
+module System.Taffybar.Information.ResourceThreadSpec
+  ( spec
+  ) where
+
+import Control.Exception (ErrorCall(..), AsyncException(..))
+import Control.Monad
+import Control.Monad.STM (throwSTM)
+import Data.Bifunctor (first)
+import Data.Coerce (coerce)
+import Data.Default
+import Data.Foldable (toList)
+import Data.IORef
+import Data.Kind (Type)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Unique (Unique, newUnique, hashUnique)
+import GHC.Generics (Generic)
+import GHC.Stack (emptyCallStack)
+import System.IO.Unsafe (unsafePerformIO)
+import Type.Reflection
+import UnliftIO.Async
+import UnliftIO.Concurrent (threadDelay)
+import UnliftIO.Exception (tryAny, bracket, Exception (..), throwIO, throwString, SomeException(..), StringException (..), try)
+import UnliftIO.STM (atomically, newEmptyTMVarIO, readTMVar, putTMVar)
+
+import Test.QuickCheck
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.StateMachine
+import Test.StateMachine.Lockstep.Simple
+import Test.StateMachine.TreeDiff (defaultExprViaShow)
+
+import System.Taffybar.Information.ResourceThread
+
+class ( Show (Effects x)
+      , Show (Handle x)
+      , Arbitrary (Effects x)
+      , Typeable x
+      ) => ModelResource x where
+  data Handle x :: Type
+  data Effects x :: Type
+
+  -- pure
+  applyEffects :: Effects x -> x -> x
+
+  -- impure
+  mkHandle :: x -> IO (Handle x)
+  doEffects :: Effects x -> Handle x -> IO ()
+
+-- | Impure helper for test resource
+allocModelResource :: ModelResource x => x -> (Handle x -> IO a) -> IO a
+allocModelResource x0 f = bracket (openX x0) closeX (f . fst)
+  where
+    openX x = (,) <$> mkHandle x <*> newIORef False
+    closeX (_, ref) = do
+      c <- atomicModifyIORef' ref (True,)
+      when c $ throwString "double-close of Handle"
+
+mkTestReqAction :: ModelResource x => Effects x -> Either AnException a -> Handle x -> IO a
+mkTestReqAction es req x = do
+  doEffects es x
+  case req of
+    Right r -> pure r
+    Left (AnException exc) -> throwIO exc
+
+------------------------------------------------------------------------
+
+-- Model state with a list of ints.
+newtype XS = XState { xstate :: [Int] }
+  deriving stock (Show, Read, Eq, Generic)
+  deriving newtype (Semigroup, Monoid)
+
+instance ModelResource XS where
+  -- Model effects of an action with a list of ints.
+  data Effects XS = XEffects [Int]
+    deriving stock (Show, Generic)
+  -- Model resource handle with IORef to state
+  newtype Handle XS = XHandle (IORef XS)
+    deriving stock (Generic)
+    deriving Show via (ShowIORef XS)
+
+  -- apply effects using list concatenation to state
+  applyEffects (XEffects es) (XState s) = XState (s <> es)
+
+  mkHandle = fmap XHandle . newIORef
+  doEffects es (XHandle ref) = atomicModifyIORef' ref $
+    \xs -> (applyEffects es xs, ())
+
+instance Arbitrary XS where
+  arbitrary = XState <$> arbitrary
+  shrink = genericShrink
+
+------------------------------------------------------------------------
+-- Test req
+
+data TestReq es = TestReq
+  { testReqEffects :: es
+    -- ^ Pre-determined effects.
+  , testReqResult :: SomeTestResult
+    -- ^ Pre-determined result.
+  } deriving (Show, Generic)
+
+-- TODO: test nested SafeReq
+
+------------------------------------------------------------------------
+-- Test result
+
+-- | Extract pre-determined result from 'TestReq'.
+runTestReq :: ModelResource x => TestReq (Effects x) -> SomeTestResult
+runTestReq = testReqResult
+
+-- | Apply pre-determined effects from 'TestReq'.
+applyTestReqEffects :: ModelResource x => TestReq (Effects x) -> x -> x
+applyTestReqEffects = applyEffects . testReqEffects
+
+-- | Existential wrapper for result of 'TestReq'.
+data SomeTestResult = forall a. (Show a, Eq a, Typeable a, Arbitrary a) => SomeTestResult
+  { getSomeResult :: Either AnException a }
+
+deriving instance Show SomeTestResult
+
+instance Eq SomeTestResult where
+  SomeTestResult (Left a) == SomeTestResult (Left b) = a == b
+  SomeTestResult (Right a) == SomeTestResult (Right b) = case eqTypeRep (typeOf a) (typeOf b) of
+    Just HRefl -> a == b
+    Nothing -> False
+  _ == _ = False
+
+
+------------------------------------------------------------------------
+-- Test result exception
+
+-- | An existential wrapper for 'Arbitrary' exceptions. Like
+-- 'SomeException' except this type isn't itself an exception.
+data AnException = forall e. Exception e => AnException { unGenException :: e }
+
+-- | 'AnException' is unwrapped and thrown in 'runReal'.  It will be
+-- caught as 'SomeException', which needs to be coerced back into
+-- 'AnException' so it can be compared with the results of 'runMock'.
+rewrap :: SomeException -> AnException
+rewrap (SomeException exc) = AnException exc
+
+-- instance Show AnException where
+--   showsPrec p (AnException exc) = showParen (p > app_prec) $
+--     showString "AnException " .
+--     showsPrec (app_prec+1) exc
+--     where app_prec = 10
+deriving instance Show AnException
+
+deriving instance Typeable AnException
+
+instance Eq AnException where
+  AnException a == AnException b = case eqTypeRep (typeOf a) (typeOf b) of
+    Just HRefl -> show a == show b
+    Nothing -> False
+
+instance Default AnException where
+  def = AnException aStringException
+
+aStringException :: StringException
+aStringException = StringException "AnException occurred" emptyCallStack
+
+instance Arbitrary AnException where
+  arbitrary = oneof
+    [ pure (AnException aStringException)
+    -- , AnException . stringException . getNonEmpty <$> arbitrary
+    , pure (AnException (ErrorCall "this is an error"))
+    -- , pure (AnException StackOverflow)
+    ]
+  shrink exc =
+    [ AnException aStringException
+    | Just se <- [fromAnException exc]
+    , se /= aStringException ]
+
+------------------------------------------------------------------------
+-- Generator for test reqs
+
+instance Arbitrary (Effects XS) where
+  arbitrary = XEffects <$> scale (`div` 2) arbitrary
+  shrink = genericShrink
+
+instance Arbitrary es => Arbitrary (TestReq es) where
+  arbitrary = TestReq <$> arbitrary <*> arbitrary
+  shrink = genericShrink
+
+instance Arbitrary SomeTestResult where
+  arbitrary = oneof
+        [ SomeTestResult <$> (genResult :: Gen (Either AnException ()))
+        , SomeTestResult <$> (genResult :: Gen (Either AnException Int))
+        , SomeTestResult <$> (genResult :: Gen (Either AnException Char))
+        ]
+    where
+      genResult :: Arbitrary a => Gen (Either AnException a)
+      genResult = frequency
+        [ (3, Right <$> arbitrary)
+        , (1, Left <$> arbitrary)
+        ]
+  shrink (SomeTestResult r) = shrinkType ++ shrinkReq
+    where
+      shrinkReq = SomeTestResult <$> shrink r
+      -- Try voiding result type if it isn't () already.
+      shrinkType = case typeOf r of
+        App _ aRep -> case eqTypeRep aRep (typeRep @()) of
+          Just HRefl -> []
+          Nothing -> [SomeTestResult (void r)]
+
+{-------------------------------------------------------------------------------
+  Instantiate the simple API
+-------------------------------------------------------------------------------}
+
+data T a
+
+data instance Cmd (T a) h
+  = New
+  | RunSafeReq (TestReq (Effects a)) h
+  | Close h
+  deriving stock (Functor, Foldable, Traversable)
+
+deriving instance (Show h, Show (Effects a)) => Show (Cmd (T a) h)
+
+data instance Resp (T a) h
+  = Var h
+  | RunResult SomeTestResult
+  | Unit ()
+  | ErrClosed
+  deriving stock (Show, Eq, Functor, Foldable, Traversable)
+
+newtype instance MockHandle (T a) = MV Int
+  deriving stock (Show, Eq, Ord, Generic)
+
+newtype instance RealHandle (T a) = RealVar
+  { getRealVar :: Opaque (UnBracket (ResourceThread (Handle a))) }
+  deriving stock (Generic, Show, Eq)
+
+instance ToExpr XS
+
+instance ToExpr (Handle XS) where
+  toExpr = defaultExprViaShow -- IORef has no Generic instance.
+
+instance ToExpr SomeTestResult where
+  toExpr = defaultExprViaShow -- Existentials can't have Generic instances.
+
+type instance MockState (T a) = Map (MockHandle (T a)) a
+
+instance ToExpr (MockHandle (T a))
+instance ToExpr (RealHandle (T a))
+
+type instance Tag (T _) = TagCmd
+
+{-------------------------------------------------------------------------------
+  Interpreters
+-------------------------------------------------------------------------------}
+
+runMock
+  :: ModelResource a
+  => a
+  -> Cmd (T a) (MockHandle (T a))
+  -> MockState (T a)
+  -> (Resp (T a) (MockHandle (T a)), MockState (T a))
+runMock e cmd m = case cmd of
+  New     -> let v = MV (Map.size m) in (Var v, Map.insert v e m)
+  Close h -> ( Unit (), Map.delete h m )
+
+  RunSafeReq req h -> case Map.lookup h m of
+    Just _  -> ( RunResult (runTestReq req)
+               , Map.adjust (applyTestReqEffects req) h m )
+    Nothing -> ( ErrClosed, m )
+
+runReal
+  :: ModelResource a
+  => a
+  -> Cmd (T a) (RealHandle (T a))
+  -> IO (Resp (T a) (RealHandle (T a)))
+runReal e cmd = case cmd of
+  New     -> Var  <$> openRealHandle e
+  Close h -> Unit <$> closeRealHandle (coerce h)
+  RunSafeReq req h -> -- either errClosed RunResult
+    errClosed2 <$> try (runRealSafeReq h req)
+
+errClosed :: ResourceUnavailableException -> Resp (T a) (RealHandle (T a))
+errClosed _ = ErrClosed
+
+errClosed2 :: Either ResourceUnavailableException SomeTestResult -> Resp (T a) (RealHandle (T a))
+errClosed2 = \case
+  Left _ -> ErrClosed
+  Right r@(SomeTestResult (Left exc)) ->
+    case fromAnException exc of
+      Just (_ :: ResourceUnavailableException) -> ErrClosed
+      Nothing -> case fromAnException exc of
+        Just (_ :: AsyncCancelled) -> ErrClosed
+        Nothing -> RunResult r
+  Right r -> RunResult r
+
+fromAnException :: forall e. Exception e => AnException -> Maybe e
+fromAnException (AnException exc) = case eqTypeRep (typeOf exc) (typeRep @e) of
+                                      Just HRefl -> Just exc
+                                      Nothing -> Nothing
+
+cleanup :: forall a. a -> Model (T a) Concrete -> IO ()
+cleanup _ (Model _ hs) = mapM_ (dealloc . getResource) hs
+  where
+    getResource = unOpaque . getRealVar . concrete . fst
+
+runRealSafeReq
+  :: ModelResource a
+  => RealHandle (T a)
+  -> TestReq (Effects a)
+  -> IO SomeTestResult
+runRealSafeReq (RealVar (Opaque ub)) (TestReq es (SomeTestResult req)) =
+  use ub >>= handleResult . resourceRunSync safeReq
+  where
+    handleResult = fmap (SomeTestResult . first rewrap) . tryAny
+    safeReq = mkSafe (mkTestReqAction es req)
+
+openRealHandle :: ModelResource a => a -> IO (RealHandle (T a))
+openRealHandle e = coerce <$> newResourceThread (allocModelResource e)
+
+closeRealHandle :: RealHandle (T a) -> IO ()
+closeRealHandle (RealVar (Opaque ub)) = dealloc ub
+
+newResourceThread :: (forall c. (Handle x -> IO c) -> IO c) -> IO (UnBracket (ResourceThread (Handle x)))
+newResourceThread use = unBracket (withResourceThread use)
+
+deleteResourceThread :: (IO (), ResourceThread x) -> IO ()
+deleteResourceThread (d, _) = d
+
+------------------------------------------------------------------------
+
+unBracket :: (forall c. (r -> IO c) -> IO c) -> IO (UnBracket r)
+unBracket withResource = do
+  var <- newEmptyTMVarIO
+  let action = atomically . putTMVar var
+      hold = forever (threadDelay maxBound)
+      use a = pollSTM a >>= maybe (readTMVar var) (const $ throwSTM ResourceUnavailable)
+
+  a <- async (withResource (\r -> action r >> hold))
+
+  UnBracket (cancel a) (atomically (use a)) <$> newUnique
+
+data UnBracket r = UnBracket
+  { dealloc :: IO ()
+  , use :: IO r
+  , ubid :: Unique
+  } deriving (Generic)
+
+instance Show (UnBracket r) where
+  show u = "UnBracket{ubid=" ++ show (hashUnique (ubid u)) ++ "}"
+
+instance Eq (UnBracket r) where
+  a == b = ubid a == ubid b
+
+
+{-------------------------------------------------------------------------------
+  Generator
+-------------------------------------------------------------------------------}
+
+generator
+  :: forall a. ModelResource a
+  => Model (T a) Symbolic
+  -> Maybe (Gen (Cmd (T a) :@ Symbolic))
+generator (Model _ hs) = Just gens
+  where
+    gens = if null hs then withoutHandle else withHandle
+
+    withoutHandle :: Gen (Cmd (T a) :@ Symbolic)
+    withoutHandle = return $ At New
+
+    withHandle :: Gen (Cmd (T a) :@ Symbolic)
+    withHandle = frequency
+      [ (15, fmap At $ RunSafeReq <$> arbitrary <*> genHandle)
+      , (1 , fmap At $ Close      <$> genHandle)
+      ]
+
+    genHandle :: Gen (Reference (RealHandle (T a)) Symbolic)
+    genHandle = elements (map fst hs)
+
+shrinker :: ModelResource a => Model (T a) Symbolic -> Cmd (T a) :@ Symbolic -> [Cmd (T a) :@ Symbolic]
+shrinker _ (At cmd) = case cmd of
+  New -> []
+  Close _ -> []
+  RunSafeReq r h -> At . flip RunSafeReq h <$> shrink r
+
+{-------------------------------------------------------------------------------
+  Tagging
+-------------------------------------------------------------------------------}
+
+data TagCmd = TagNew | TagRun TagRunSafeReq | TagClose
+  deriving stock (Show)
+
+tagCmds :: [Event (T a) Symbolic] -> [TagCmd]
+tagCmds = map (aux . unAt . cmd)
+  where
+    aux :: Cmd (T a) h -> TagCmd
+    aux New              = TagNew
+    aux (RunSafeReq r _) = TagRun (tagRun r)
+    aux (Close        _) = TagClose
+
+data TagRunSafeReq = TagRunSafeReq
+  deriving stock (Show)
+
+tagRun :: TestReq a -> TagRunSafeReq
+tagRun _req = TagRunSafeReq
+
+{-------------------------------------------------------------------------------
+  Wrapping it all up
+-------------------------------------------------------------------------------}
+
+ioRefTest :: StateMachineTest (T XS)
+ioRefTest = StateMachineTest {
+      initMock   = mempty
+    , generator  = System.Taffybar.Information.ResourceThreadSpec.generator
+    , shrinker   = System.Taffybar.Information.ResourceThreadSpec.shrinker
+    , newHandles = toList
+    , runMock    = System.Taffybar.Information.ResourceThreadSpec.runMock mempty
+    , runReal    = System.Taffybar.Information.ResourceThreadSpec.runReal mempty
+    , cleanup    = System.Taffybar.Information.ResourceThreadSpec.cleanup mempty
+    , tag        = tagCmds
+    }
+
+{-------------------------------------------------------------------------------
+  Spec
+-------------------------------------------------------------------------------}
+
+prop_resourceThread_sequential :: Property
+prop_resourceThread_sequential = prop_sequential ioRefTest Nothing
+
+prop_resourceThread_parallel :: Property
+prop_resourceThread_parallel = prop_parallel ioRefTest Nothing
+
+spec :: Spec
+spec = describe "ResourceThread state machine" $ do
+  prop "sequential" prop_resourceThread_sequential
+  prop "parallel" prop_resourceThread_parallel
+  -- prop "ResourceThread property" prop_resourceThread
+
+------------------------------------------------------------------------
+-- misc
+
+-- | Type wrapper to make a naughty showable IORef.
+newtype ShowIORef a = ShowIORef (IORef a)
+
+instance Show a => Show (ShowIORef a) where
+  show (ShowIORef ref) = "IORef<<" ++ show (unsafePerformIO $ readIORef ref) ++ ">>"
+
+-- | Wrapper with ability to show the type of an IO action.
+newtype ShowIOFunc x r = ShowIOFunc (x -> IO r)
+instance forall x r. (Typeable x, Typeable r) => Show (ShowIOFunc x r) where
+  show _f = "_ :: " ++ show (TypeRep @x) ++ " -> IO " ++ show (TypeRep @r)

--- a/test/unit/System/Taffybar/Information/X11DesktopInfoSpec.hs
+++ b/test/unit/System/Taffybar/Information/X11DesktopInfoSpec.hs
@@ -1,27 +1,123 @@
 {-# LANGUAGE FlexibleInstances #-}
 
-module System.Taffybar.Information.X11DesktopInfoSpec (spec) where
+module System.Taffybar.Information.X11DesktopInfoSpec
+  ( spec
+  , runX11
+  , TestEvent
+  , TestEvent' (..)
+  , TestAtom (..)
+  ) where
 
+import Control.Monad (forM, (<=<))
+import Control.Monad.Trans.Reader (ReaderT (..))
+import Data.Word (Word32)
+import GHC.Generics (Generic)
 import System.Taffybar.Information.X11DesktopInfo
+import System.Taffybar.Test.UtilSpec hiding (spec)
 import System.Taffybar.Test.XvfbSpec (XPropName (..), XPropValue (..), withXdummy, xpropSet)
 import Test.Hspec hiding (context)
+import Test.QuickCheck
+import Test.QuickCheck.Monadic
+import UnliftIO.Exception (evaluate)
+import UnliftIO.STM (atomically, newTChan, readTChan, writeTChan)
 
 spec :: Spec
-spec = around withXdummy $ describe "withX11Context" $ do
+spec = logSetup $ aroundAll withXdummy $ do
+  withX11ContextSpec
+  eventLoopSpec
+
+withX11ContextSpec :: SpecWith DisplayName
+withX11ContextSpec = describe "withX11Context" $ do
   it "trivial" $ \dn ->
-    example $
-      withX11Context dn (pure ()) `shouldReturn` ()
+    example $ runX11 dn (pure ()) `shouldReturn` ()
 
   it "getPrimaryOutputNumber" $ \dn ->
-    example $
-      withX11Context dn getPrimaryOutputNumber `shouldReturn` Just 0
+    example $ runX11 dn getPrimaryOutputNumber `shouldReturn` Just 0
 
   it "read property of root window" $ \dn -> do
     xpropSet dn (XPropName "_XMONAD_VISIBLE_WORKSPACES") (XPropValue "hello")
-    ws <- withX11Context dn (readAsListOfString Nothing "_XMONAD_VISIBLE_WORKSPACES")
+    ws <- runX11 dn (readAsListOfString Nothing "_XMONAD_VISIBLE_WORKSPACES")
     ws `shouldBe` ["hello"]
 
-  it "send something" $ \dn -> do
-    withX11Context dn $ do
+  it "send something" $ \dn ->
+    runX11 dn $ do
       atom <- getAtom "iamanatom"
       sendCommandEvent atom 42
+
+eventLoopSpec :: SpecWith DisplayName
+eventLoopSpec = describe "eventLoop" $ around_ (laxTimeout' 4_000_000) $ do
+  it "receives command events" $ property . withMaxSuccess 50 . noShrinking . prop_eventLoop_sendCommandEvents
+  it "hammer trivial " $ property . withMaxSuccess 50 . prop_eventLoop_trivial
+
+prop_eventLoop_trivial :: DisplayName -> Property
+prop_eventLoop_trivial dn = monadicIO $ run $
+  withX11EventLoop dn (const $ pure ()) (pure ())
+
+------------------------------------------------------------------------
+
+type TestEvent = TestEvent' TestAtom
+
+data TestEvent' a = TestEvent
+  { testEventArg1 :: !a
+  -- | @XClientMessageEvent@ data holds up to five 32-bit values
+  , testEventArg2 :: !Word32
+  }
+  deriving (Show, Read, Eq, Generic)
+
+newtype TestAtom = TestAtom {getTestAtom :: String}
+  deriving (Show, Read, Eq, Ord, Generic)
+
+instance Arbitrary TestEvent where
+  arbitrary = TestEvent <$> arbitrary <*> arbitrary
+  shrink = genericShrink
+
+instance Arbitrary TestAtom where
+  arbitrary = TestAtom <$> listOf1 (chooseEnum ('a', 'z'))
+  shrink = map TestAtom . filter (not . null) . shrink . getTestAtom
+
+newtype TestEventLoop = TestEventLoop {getBatches :: [[TestEvent]]}
+  deriving (Show, Read, Eq, Generic)
+
+instance Arbitrary TestEventLoop where
+  arbitrary = fmap TestEventLoop $ gg <$> evs <*> infiniteListOf batchSize
+    where
+      evs = fmap getNonEmpty arbitrary
+      batchSize = sized $ \n -> choose (1, ceiling (sqrt (fromIntegral n) :: Double))
+
+      gg :: [a] -> [Int] -> [[a]]
+      gg [] _ = []
+      gg _ [] = []
+      gg xs (n : ns) = take n xs : gg (drop n xs) ns
+
+  shrink = shrinkMap (TestEventLoop . map getNonEmpty . getNonEmpty) (NonEmpty . map NonEmpty . getBatches)
+
+prop_eventLoop_sendCommandEvents :: DisplayName -> TestEventLoop -> Property
+prop_eventLoop_sendCommandEvents dn (TestEventLoop batches) = monadicIO $ fmap conjoin $
+  run $ runX11 dn $ do
+    chan <- atomically newTChan
+    let handler = atomically . writeTChan chan <=< evaluate . getClientMessageEvent
+        handler' e = specLog "Handling an event now" >> handler e
+    withX11EventLoop dn handler' $
+      forM batches $ \msgs -> do
+        sent <- forM msgs $ \(TestEvent (TestAtom s) param) -> do
+          atom <- getAtom s
+          specLog "Sending command event"
+          sendCommandEvent atom (fromIntegral param)
+          pure $ TestEvent atom param
+
+        fmap conjoin $ forM sent $ \cmd -> do
+          specLog "Reading channel"
+          recv <- atomically $ readTChan chan
+          specLog "Got something from chan"
+          pure $ recv === Right cmd
+
+getClientMessageEvent :: Event -> Either Word32 (TestEvent' Atom)
+getClientMessageEvent ClientMessageEvent {..} = case ev_data of
+  arg1 : _ -> Right (TestEvent ev_message_type (fromIntegral arg1))
+  [] -> Left ev_event_type
+getClientMessageEvent e = Left (ev_event_type e)
+
+------------------------------------------------------------------------
+
+runX11 :: DisplayName -> ReaderT X11Context IO a -> IO a
+runX11 dn f = withX11Context dn (runReaderT f)

--- a/test/unit/System/Taffybar/Information/X11DesktopInfoSpec.hs
+++ b/test/unit/System/Taffybar/Information/X11DesktopInfoSpec.hs
@@ -1,123 +1,27 @@
 {-# LANGUAGE FlexibleInstances #-}
 
-module System.Taffybar.Information.X11DesktopInfoSpec
-  ( spec
-  , runX11
-  , TestEvent
-  , TestEvent' (..)
-  , TestAtom (..)
-  ) where
+module System.Taffybar.Information.X11DesktopInfoSpec (spec) where
 
-import Control.Monad (forM, (<=<))
-import Control.Monad.Trans.Reader (ReaderT (..))
-import Data.Word (Word32)
-import GHC.Generics (Generic)
 import System.Taffybar.Information.X11DesktopInfo
-import System.Taffybar.Test.UtilSpec hiding (spec)
 import System.Taffybar.Test.XvfbSpec (XPropName (..), XPropValue (..), withXdummy, xpropSet)
 import Test.Hspec hiding (context)
-import Test.QuickCheck
-import Test.QuickCheck.Monadic
-import UnliftIO.Exception (evaluate)
-import UnliftIO.STM (atomically, newTChan, readTChan, writeTChan)
 
 spec :: Spec
-spec = logSetup $ aroundAll withXdummy $ do
-  withX11ContextSpec
-  eventLoopSpec
-
-withX11ContextSpec :: SpecWith DisplayName
-withX11ContextSpec = describe "withX11Context" $ do
+spec = around withXdummy $ describe "withX11Context" $ do
   it "trivial" $ \dn ->
-    example $ runX11 dn (pure ()) `shouldReturn` ()
+    example $
+      withX11Context dn (pure ()) `shouldReturn` ()
 
   it "getPrimaryOutputNumber" $ \dn ->
-    example $ runX11 dn getPrimaryOutputNumber `shouldReturn` Just 0
+    example $
+      withX11Context dn getPrimaryOutputNumber `shouldReturn` Just 0
 
   it "read property of root window" $ \dn -> do
     xpropSet dn (XPropName "_XMONAD_VISIBLE_WORKSPACES") (XPropValue "hello")
-    ws <- runX11 dn (readAsListOfString Nothing "_XMONAD_VISIBLE_WORKSPACES")
+    ws <- withX11Context dn (readAsListOfString Nothing "_XMONAD_VISIBLE_WORKSPACES")
     ws `shouldBe` ["hello"]
 
-  it "send something" $ \dn ->
-    runX11 dn $ do
+  it "send something" $ \dn -> do
+    withX11Context dn $ do
       atom <- getAtom "iamanatom"
       sendCommandEvent atom 42
-
-eventLoopSpec :: SpecWith DisplayName
-eventLoopSpec = describe "eventLoop" $ around_ (laxTimeout' 4_000_000) $ do
-  it "receives command events" $ property . withMaxSuccess 50 . noShrinking . prop_eventLoop_sendCommandEvents
-  it "hammer trivial " $ property . withMaxSuccess 50 . prop_eventLoop_trivial
-
-prop_eventLoop_trivial :: DisplayName -> Property
-prop_eventLoop_trivial dn = monadicIO $ run $
-  withX11EventLoop dn (const $ pure ()) (pure ())
-
-------------------------------------------------------------------------
-
-type TestEvent = TestEvent' TestAtom
-
-data TestEvent' a = TestEvent
-  { testEventArg1 :: !a
-  -- | @XClientMessageEvent@ data holds up to five 32-bit values
-  , testEventArg2 :: !Word32
-  }
-  deriving (Show, Read, Eq, Generic)
-
-newtype TestAtom = TestAtom {getTestAtom :: String}
-  deriving (Show, Read, Eq, Ord, Generic)
-
-instance Arbitrary TestEvent where
-  arbitrary = TestEvent <$> arbitrary <*> arbitrary
-  shrink = genericShrink
-
-instance Arbitrary TestAtom where
-  arbitrary = TestAtom <$> listOf1 (chooseEnum ('a', 'z'))
-  shrink = map TestAtom . filter (not . null) . shrink . getTestAtom
-
-newtype TestEventLoop = TestEventLoop {getBatches :: [[TestEvent]]}
-  deriving (Show, Read, Eq, Generic)
-
-instance Arbitrary TestEventLoop where
-  arbitrary = fmap TestEventLoop $ gg <$> evs <*> infiniteListOf batchSize
-    where
-      evs = fmap getNonEmpty arbitrary
-      batchSize = sized $ \n -> choose (1, ceiling (sqrt (fromIntegral n) :: Double))
-
-      gg :: [a] -> [Int] -> [[a]]
-      gg [] _ = []
-      gg _ [] = []
-      gg xs (n : ns) = take n xs : gg (drop n xs) ns
-
-  shrink = shrinkMap (TestEventLoop . map getNonEmpty . getNonEmpty) (NonEmpty . map NonEmpty . getBatches)
-
-prop_eventLoop_sendCommandEvents :: DisplayName -> TestEventLoop -> Property
-prop_eventLoop_sendCommandEvents dn (TestEventLoop batches) = monadicIO $ fmap conjoin $
-  run $ runX11 dn $ do
-    chan <- atomically newTChan
-    let handler = atomically . writeTChan chan <=< evaluate . getClientMessageEvent
-        handler' e = specLog "Handling an event now" >> handler e
-    withX11EventLoop dn handler' $
-      forM batches $ \msgs -> do
-        sent <- forM msgs $ \(TestEvent (TestAtom s) param) -> do
-          atom <- getAtom s
-          specLog "Sending command event"
-          sendCommandEvent atom (fromIntegral param)
-          pure $ TestEvent atom param
-
-        fmap conjoin $ forM sent $ \cmd -> do
-          specLog "Reading channel"
-          recv <- atomically $ readTChan chan
-          specLog "Got something from chan"
-          pure $ recv === Right cmd
-
-getClientMessageEvent :: Event -> Either Word32 (TestEvent' Atom)
-getClientMessageEvent ClientMessageEvent {..} = case ev_data of
-  arg1 : _ -> Right (TestEvent ev_message_type (fromIntegral arg1))
-  [] -> Left ev_event_type
-getClientMessageEvent e = Left (ev_event_type e)
-
-------------------------------------------------------------------------
-
-runX11 :: DisplayName -> ReaderT X11Context IO a -> IO a
-runX11 dn f = withX11Context dn (runReaderT f)


### PR DESCRIPTION
This PR is a rebased continuation of #596 onto current `master`.

Why a new PR:
- #596 is cross-repo (`rvl/resource-cleanup`) with `maintainerCanModify=false`, so it could not be updated directly.

What this includes:
- Rebases the #596 commit stack onto `master`
- Resolves merge conflicts against current code
- Adds follow-up fix commit to restore compile/test compatibility after rebase fallout

Validation:
- `cabal build test:unit` passes in the rebased worktree

Supersedes: #596
