### PR TITLE
[codex] Fix backend detection and X11 strut sizing

### DIFF
--- a/packages/dbus-hslogger/Setup.hs
+++ b/packages/dbus-hslogger/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/packages/dbus-hslogger/app/Main.hs
+++ b/packages/dbus-hslogger/app/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import Control.Monad
@@ -11,39 +12,44 @@ import System.Log.DBus.Client
 levelP :: Parser String
 levelP =
   strOption
-  (  long "level"
-  <> short 'l'
-  <> help "The level to which to set the log"
-  <> metavar "LEVEL"
-  <> value "INFO"
-  )
+    ( long "level"
+        <> short 'l'
+        <> help "The level to which to set the log"
+        <> metavar "LEVEL"
+        <> value "INFO"
+    )
 
 prefixP :: Parser String
 prefixP =
   strOption
-  (  long "prefix"
-  <> short 'p'
-  <> help "The log prefix whose level will be set"
-  <> metavar "PREFIX"
-  <> value "System.Taffybar"
-  )
+    ( long "prefix"
+        <> short 'p'
+        <> help "The log prefix whose level will be set"
+        <> metavar "PREFIX"
+        <> value "System.Taffybar"
+    )
 
 busNameP :: Parser BusName
-busNameP = busName_ <$>
-  strOption
-  (  long "bus-name"
-  <> short 'b'
-  <> help "The bus name to which the message should be sent"
-  <> value "org.taffybar.Bar"
-  )
+busNameP =
+  busName_
+    <$> strOption
+      ( long "bus-name"
+          <> short 'b'
+          <> help "The bus name to which the message should be sent"
+          <> value "org.taffybar.Bar"
+      )
 
 doSetLogLevel :: Client -> Parser (IO (Either MethodError ()))
 doSetLogLevel client = setLogLevel client <$> busNameP <*> prefixP <*> levelP
 
 main = do
   client <- connectSession
-  res <- join $ execParser $
-         info (doSetLogLevel client <**> helper)
-              (  fullDesc
-              <> progDesc "Set the log level of a running process")
+  res <-
+    join $
+      execParser $
+        info
+          (doSetLogLevel client <**> helper)
+          ( fullDesc
+              <> progDesc "Set the log level of a running process"
+          )
   print res

--- a/packages/dbus-hslogger/src/System/Log/DBus/Client.hs
+++ b/packages/dbus-hslogger/src/System/Log/DBus/Client.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE TemplateHaskell #-}
+
 module System.Log.DBus.Client where
 
 import DBus.Generation
 import System.Log.DBus.Server
 
-generateClient defaultGenerationParams { genObjectPath = Just logPath }
-               logIntrospectionInterface
+generateClient
+  defaultGenerationParams {genObjectPath = Just logPath}
+  logIntrospectionInterface

--- a/packages/dbus-hslogger/src/System/Log/DBus/Server.hs
+++ b/packages/dbus-hslogger/src/System/Log/DBus/Server.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module System.Log.DBus.Server where
 
-import           Data.IORef
-import           Data.Map (Map)
-import qualified Data.Map as Map
-import           DBus
-import           DBus.Client
+import DBus
+import DBus.Client
 import qualified DBus.Introspection as I
-import           System.Log.Logger
-import           Text.Read
+import Data.IORef
+import Data.Map (Map)
+import qualified Data.Map as Map
+import System.Log.Logger
+import Text.Read
 
 maybeToEither :: b -> Maybe a -> Either b a
 maybeToEither = flip maybe Right . Left
@@ -26,8 +27,8 @@ setLogLevelTracked (LogServer ref) logPrefix level = do
   getLogger logPrefix >>= saveGlobalLogger . setLevel level
   modifyIORef' ref (Map.insert logPrefix level)
 
-setLogLevelFromPriorityStringTracked
-  :: LogServer -> String -> String -> IO (Either Reply ())
+setLogLevelFromPriorityStringTracked ::
+  LogServer -> String -> String -> IO (Either Reply ())
 setLogLevelFromPriorityStringTracked server logPrefix levelString =
   case readMaybe levelString of
     Just level -> Right <$> setLogLevelTracked server logPrefix level
@@ -48,24 +49,28 @@ getConfiguredLogLevels (LogServer ref) =
 
 -- | Build the D-Bus interface with tracking and introspection methods.
 logInterfaceWithServer :: LogServer -> Interface
-logInterfaceWithServer server = defaultInterface
-  { interfaceName = "org.taffybar.LogServer"
-  , interfaceMethods =
-      [ autoMethod "SetLogLevel"
-          (setLogLevelFromPriorityStringTracked server)
-      , autoMethod "GetLogLevel" getLogLevel
-      , autoMethod "GetConfiguredLogLevels"
-          (getConfiguredLogLevels server)
-      ]
-  }
+logInterfaceWithServer server =
+  defaultInterface
+    { interfaceName = "org.taffybar.LogServer",
+      interfaceMethods =
+        [ autoMethod
+            "SetLogLevel"
+            (setLogLevelFromPriorityStringTracked server),
+          autoMethod "GetLogLevel" getLogLevel,
+          autoMethod
+            "GetConfiguredLogLevels"
+            (getConfiguredLogLevels server)
+        ]
+    }
 
 -- | The original interface with only 'SetLogLevel'. Kept for backward
 -- compatibility.
 logInterface :: Interface
-logInterface = defaultInterface
-  { interfaceName = "org.taffybar.LogServer"
-  , interfaceMethods = [ autoMethod "SetLogLevel" setLogLevelFromPriorityString ]
-  }
+logInterface =
+  defaultInterface
+    { interfaceName = "org.taffybar.LogServer",
+      interfaceMethods = [autoMethod "SetLogLevel" setLogLevelFromPriorityString]
+    }
 
 logPath :: ObjectPath
 logPath = "/org/taffybar/LogServer"
@@ -86,22 +91,24 @@ startLogServer client =
 -- | Introspection interface including all methods (SetLogLevel, GetLogLevel,
 -- GetConfiguredLogLevels). Suitable for TH client generation.
 logIntrospectionInterface :: I.Interface
-logIntrospectionInterface = buildIntrospectionInterface $
-  defaultInterface
-    { interfaceName = "org.taffybar.LogServer"
-    , interfaceMethods =
-        [ autoMethod "SetLogLevel" setLogLevelFromPriorityString
-        , autoMethod "GetLogLevel" getLogLevel
-        , autoMethod "GetConfiguredLogLevels"
-            (return Map.empty :: IO (Map String String))
-        ]
-    }
+logIntrospectionInterface =
+  buildIntrospectionInterface $
+    defaultInterface
+      { interfaceName = "org.taffybar.LogServer",
+        interfaceMethods =
+          [ autoMethod "SetLogLevel" setLogLevelFromPriorityString,
+            autoMethod "GetLogLevel" getLogLevel,
+            autoMethod
+              "GetConfiguredLogLevels"
+              (return Map.empty :: IO (Map String String))
+          ]
+      }
 
 setLogLevelFromPriorityString :: String -> String -> IO (Either Reply ())
 setLogLevelFromPriorityString logPrefix levelString =
   let maybePriority = readMaybe levelString
-      getMaybeResult = sequenceA $ setLogLevel logPrefix <$> maybePriority
-  in maybeToEither (ReplyError errorInvalidParameters []) <$> getMaybeResult
+      getMaybeResult = traverse (setLogLevel logPrefix) maybePriority
+   in maybeToEither (ReplyError errorInvalidParameters []) <$> getMaybeResult
 
 setLogLevel :: String -> Priority -> IO ()
 setLogLevel logPrefix level =

--- a/packages/dbus-menu/src/DBusMenu.hs
+++ b/packages/dbus-menu/src/DBusMenu.hs
@@ -1,72 +1,74 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module DBusMenu
   ( -- * High-level menu construction
-    buildMenu
-  , populateGtkMenu
-  , buildGtkMenuItem
+    buildMenu,
+    populateGtkMenu,
+    buildGtkMenuItem,
 
     -- * DBusMenu protocol operations
-  , getLayout
-  , aboutToShow
-  , sendClicked
+    getLayout,
+    aboutToShow,
+    sendClicked,
 
     -- * Layout tree
-  , LayoutNode(..)
-  , variantToLayout
-  , tupleToLayout
+    LayoutNode (..),
+    variantToLayout,
+    tupleToLayout,
 
     -- * Layout node property accessors
-  , menuItemType
-  , menuItemLabel
-  , menuItemVisible
-  , menuItemEnabled
-  , menuItemChildrenDisplay
-  , menuItemToggleType
-  , menuItemToggleState
-  ) where
+    menuItemType,
+    menuItemLabel,
+    menuItemVisible,
+    menuItemEnabled,
+    menuItemChildrenDisplay,
+    menuItemToggleType,
+    menuItemToggleState,
+  )
+where
 
 import Control.Concurrent (forkIO)
 import Control.Exception.Enclosed (catchAny)
 import Control.Monad (forM_, void, when)
-import Data.Int (Int32)
+import DBus
+import DBus.Client
+import qualified DBusMenu.Client as DM
+import Data.Either (fromRight)
+import Data.GI.Base (unsafeCastTo)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
+import Data.Int (Int32)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import Data.Word (Word32)
-import DBus
-import DBus.Client
-import Data.GI.Base (unsafeCastTo)
 import Foreign.Ptr (Ptr, nullPtr)
 import Foreign.StablePtr
-  ( StablePtr
-  , castPtrToStablePtr
-  , castStablePtrToPtr
-  , deRefStablePtr
-  , freeStablePtr
-  , newStablePtr
+  ( StablePtr,
+    castPtrToStablePtr,
+    castStablePtrToPtr,
+    deRefStablePtr,
+    freeStablePtr,
+    newStablePtr,
   )
 import qualified GI.GLib as GLib
 import qualified GI.GObject.Objects.Object as GObject
 import qualified GI.Gtk as Gtk
-import System.Log.Logger (Priority(..), logM)
+import System.Log.Logger (Priority (..), logM)
 import Text.Printf
-
-import qualified DBusMenu.Client as DM
 
 dbusMenuLogger :: Priority -> String -> IO ()
 dbusMenuLogger = logM "DBusMenu"
 
 layoutPropNames :: [String]
 layoutPropNames =
-  [ "type"
-  , "label"
-  , "visible"
-  , "enabled"
-  , "children-display"
-  , "toggle-type"
-  , "toggle-state"
+  [ "type",
+    "label",
+    "visible",
+    "enabled",
+    "children-display",
+    "toggle-type",
+    "toggle-state"
   ]
 
 addCssClass :: Gtk.Widget -> T.Text -> IO ()
@@ -75,10 +77,11 @@ addCssClass widget cssClass =
 
 -- | A node in the DBusMenu layout tree.
 data LayoutNode = LayoutNode
-  { lnId :: Int32
-  , lnProps :: Map String Variant
-  , lnChildren :: [LayoutNode]
-  } deriving (Eq, Show)
+  { lnId :: Int32,
+    lnProps :: Map String Variant,
+    lnChildren :: [LayoutNode]
+  }
+  deriving (Eq, Show)
 
 type LayoutTuple = (Int32, Map String Variant, [Variant])
 
@@ -135,15 +138,15 @@ variantToLayout :: Variant -> Maybe LayoutNode
 variantToLayout v = do
   (i, props, kids) <- fromVariant v :: Maybe LayoutTuple
   children <- traverse variantToLayout kids
-  pure LayoutNode { lnId = i, lnProps = props, lnChildren = children }
+  pure LayoutNode {lnId = i, lnProps = props, lnChildren = children}
 
 -- | Convert a raw layout tuple into a LayoutNode.
 tupleToLayout :: LayoutTuple -> LayoutNode
 tupleToLayout (i, props, kids) =
   LayoutNode
-    { lnId = i
-    , lnProps = props
-    , lnChildren = [ n | v <- kids, Just n <- [variantToLayout v] ]
+    { lnId = i,
+      lnProps = props,
+      lnChildren = [n | v <- kids, Just n <- [variantToLayout v]]
     }
 
 -- | Unwrap an Either MethodError, failing on Left.
@@ -155,13 +158,14 @@ unwrapCall _ (Right a) = pure a
 -- Returns True if the service indicates an update is needed.
 aboutToShow :: Client -> BusName -> ObjectPath -> Int32 -> IO Bool
 aboutToShow client dest path i =
-  either (const False) id <$> DM.aboutToShow client dest path i
+  fromRight False <$> DM.aboutToShow client dest path i
 
 -- | Fetch the layout tree from the DBusMenu service.
 getLayout :: Client -> BusName -> ObjectPath -> Int32 -> Int32 -> [String] -> IO (Word32, LayoutNode)
 getLayout client dest path parentId depth propNames = do
-  (rev, tup) <- unwrapCall "GetLayout" =<<
-    DM.getLayout client dest path parentId depth propNames
+  (rev, tup) <-
+    unwrapCall "GetLayout"
+      =<< DM.getLayout client dest path parentId depth propNames
   pure (rev, tupleToLayout tup)
 
 -- | Send a \"clicked\" event to the DBusMenu service for the given item.
@@ -169,39 +173,48 @@ getLayout client dest path parentId depth propNames = do
 sendClicked :: Client -> BusName -> ObjectPath -> Int32 -> Word32 -> IO ()
 sendClicked client dest path itemId ts = do
   dbusMenuLogger DEBUG $
-    printf "sendClicked: id=%d dest=%s path=%s ts=%d"
-           itemId (show dest) (show path) ts
-  let mc = DM.eventMethodCall
-        { methodCallDestination = Just dest
-        , methodCallPath = path
-        , methodCallBody =
-            [ toVariant itemId
-            , toVariant ("clicked" :: String)
-            , toVariant (toVariant (0 :: Int32))
-            , toVariant ts
-            ]
-        }
+    printf
+      "sendClicked: id=%d dest=%s path=%s ts=%d"
+      itemId
+      (show dest)
+      (show path)
+      ts
+  let mc =
+        DM.eventMethodCall
+          { methodCallDestination = Just dest,
+            methodCallPath = path,
+            methodCallBody =
+              [ toVariant itemId,
+                toVariant ("clicked" :: String),
+                toVariant (toVariant (0 :: Int32)),
+                toVariant ts
+              ]
+          }
   -- Send on a forked thread to avoid blocking GTK; use `call` instead of
   -- `callNoReply` so we can detect service errors.
-  void $ forkIO $ catchAny
-    (do result <- call client mc
-        case result of
-          Left err -> dbusMenuLogger WARNING $
-            printf "sendClicked: Event error: %s" (show err)
-          Right _ -> dbusMenuLogger DEBUG "sendClicked: Event succeeded")
-    (\e -> dbusMenuLogger WARNING $
-           printf "sendClicked: Event exception: %s" (show e))
+  void $
+    forkIO $
+      catchAny
+        ( do
+            result <- call client mc
+            case result of
+              Left err ->
+                dbusMenuLogger WARNING $
+                  printf "sendClicked: Event error: %s" (show err)
+              Right _ -> dbusMenuLogger DEBUG "sendClicked: Event succeeded"
+        )
+        (dbusMenuLogger WARNING . printf "sendClicked: Event exception: %s" . show)
 
 getPropS :: String -> LayoutNode -> Maybe String
-getPropS key LayoutNode { lnProps = props } =
+getPropS key LayoutNode {lnProps = props} =
   Map.lookup key props >>= fromVariant
 
 getPropB :: String -> LayoutNode -> Maybe Bool
-getPropB key LayoutNode { lnProps = props } =
+getPropB key LayoutNode {lnProps = props} =
   Map.lookup key props >>= fromVariant
 
 getPropI32 :: String -> LayoutNode -> Maybe Int32
-getPropI32 key LayoutNode { lnProps = props } =
+getPropI32 key LayoutNode {lnProps = props} =
   Map.lookup key props >>= fromVariant
 
 -- | The item type (e.g. @\"separator\"@), or Nothing for standard items.
@@ -340,19 +353,23 @@ buildGtkMenuItem' client dest path dispatch _parentMenu node = do
       -- Register click action in the menu-level dispatch table.
       let itemId = lnId node
       atomicModifyIORef' dispatch $ \m ->
-        ( Map.insert itemId (sendClicked client dest path itemId =<< Gtk.getCurrentEventTime) m
-        , ()
+        ( Map.insert itemId (sendClicked client dest path itemId =<< Gtk.getCurrentEventTime) m,
+          ()
         )
       -- Thin trampoline: look up action from the persistent dispatch table
       -- at activation time rather than capturing it in a per-widget closure.
-      _ <- Gtk.onMenuItemActivate item $ catchAny
-        (do actions <- readIORef dispatch
-            case Map.lookup itemId actions of
-              Just action -> action
-              Nothing -> dbusMenuLogger WARNING $
-                printf "Dispatch: no action for item %d" itemId)
-        (\e -> dbusMenuLogger WARNING $
-               printf "Menu item %d dispatch failed: %s" itemId (show e))
+      _ <-
+        Gtk.onMenuItemActivate item $
+          catchAny
+            ( do
+                actions <- readIORef dispatch
+                case Map.lookup itemId actions of
+                  Just action -> action
+                  Nothing ->
+                    dbusMenuLogger WARNING $
+                      printf "Dispatch: no action for item %d" itemId
+            )
+            (dbusMenuLogger WARNING . printf "Menu item %d dispatch failed: %s" itemId . show)
       pure ()
     else do
       addCssClass itemW "dbusmenu-has-submenu"
@@ -365,25 +382,31 @@ buildGtkMenuItem' client dest path dispatch _parentMenu node = do
       -- the service doesn't support/require lazy updates.
       populateGtkMenu' client dest path dispatch submenu node
       loadedRef <- newIORef (not (null (lnChildren node)))
-      let refresh = void $ forkIO $ catchAny
-            (do -- Run DBus calls on a forked thread to avoid blocking the GTK
-                -- main loop (which would cause queued click events to be lost
-                -- when populateGtkMenu rebuilds menu items).
-                needUpdate <- aboutToShow client dest path (lnId node)
-                loaded <- readIORef loadedRef
-                when (needUpdate || not loaded) $ do
-                  (_, layout) <- getLayout client dest path (lnId node) 1 layoutPropNames
-                  -- Post GTK updates back on the main thread.  Using
-                  -- PRIORITY_DEFAULT_IDLE ensures pending input events (clicks)
-                  -- are processed first.
-                  void $ GLib.idleAdd GLib.PRIORITY_DEFAULT_IDLE $ do
-                    populateGtkMenu' client dest path dispatch submenu layout
-                    writeIORef loadedRef True
-                    Gtk.widgetShowAll submenu
-                    return False)
-            (\e -> dbusMenuLogger WARNING $
-                   printf "Submenu %d refresh failed (stale ID?): %s"
-                          (lnId node) (show e))
+      let refresh =
+            void $
+              forkIO $
+                catchAny
+                  ( do
+                      -- Run DBus calls on a forked thread to avoid blocking the GTK
+                      -- main loop (which would cause queued click events to be lost
+                      -- when populateGtkMenu rebuilds menu items).
+                      needUpdate <- aboutToShow client dest path (lnId node)
+                      loaded <- readIORef loadedRef
+                      when (needUpdate || not loaded) $ do
+                        (_, layout) <- getLayout client dest path (lnId node) 1 layoutPropNames
+                        -- Post GTK updates back on the main thread.  Using
+                        -- PRIORITY_DEFAULT_IDLE ensures pending input events (clicks)
+                        -- are processed first.
+                        void $ GLib.idleAdd GLib.PRIORITY_DEFAULT_IDLE $ do
+                          populateGtkMenu' client dest path dispatch submenu layout
+                          writeIORef loadedRef True
+                          Gtk.widgetShowAll submenu
+                          return False
+                  )
+                  ( dbusMenuLogger WARNING
+                      . printf "Submenu %d refresh failed (stale ID?): %s" (lnId node)
+                      . show
+                  )
       _ <- Gtk.onWidgetShow submenu $ do
         refresh
         Gtk.widgetShowAll submenu

--- a/packages/dbus-menu/src/DBusMenu/Client.hs
+++ b/packages/dbus-menu/src/DBusMenu/Client.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE TemplateHaskell #-}
+
 module DBusMenu.Client where
 
 import DBus.Generation
-import System.FilePath
 import DBusMenu.Client.Util
+import System.FilePath
 
 -- Generates DBus client functions/signals for the com.canonical.dbusmenu
 -- interface from introspection XML, similar to Taffybar's approach.
 generateClientFromFile
   defaultRecordGenerationParams
-  defaultGenerationParams { genTakeSignalErrorHandler = True }
+  defaultGenerationParams {genTakeSignalErrorHandler = True}
   False
   ("dbus-xml" </> "com.canonical.dbusmenu.xml")

--- a/packages/dbus-menu/src/DBusMenu/Client/Util.hs
+++ b/packages/dbus-menu/src/DBusMenu/Client/Util.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
+
 module DBusMenu.Client.Util
-  ( RecordGenerationParams(..)
-  , GetTypeForName
-  , defaultRecordGenerationParams
-  , generateClientFromFile
-  ) where
+  ( RecordGenerationParams (..),
+    GetTypeForName,
+    defaultRecordGenerationParams,
+    generateClientFromFile,
+  )
+where
 
 import Control.Monad (forM)
 import DBus (ObjectPath)
@@ -23,17 +25,18 @@ import Language.Haskell.TH.Syntax (addDependentFile, makeRelativeToProject)
 type GetTypeForName = String -> DBusTypes.Type -> Maybe Type
 
 data RecordGenerationParams = RecordGenerationParams
-  { recordName :: Maybe String
-  , recordPrefix :: String
-  , recordTypeForName :: GetTypeForName
+  { recordName :: Maybe String,
+    recordPrefix :: String,
+    recordTypeForName :: GetTypeForName
   }
 
 defaultRecordGenerationParams :: RecordGenerationParams
-defaultRecordGenerationParams = RecordGenerationParams
-  { recordName = Nothing
-  , recordPrefix = "_"
-  , recordTypeForName = const $ const Nothing
-  }
+defaultRecordGenerationParams =
+  RecordGenerationParams
+    { recordName = Nothing,
+      recordPrefix = "_",
+      recordTypeForName = const $ const Nothing
+    }
 
 deriveShowAndEQ :: [DerivClause]
 deriveShowAndEQ =
@@ -44,43 +47,42 @@ buildDataFromNameTypePairs name pairs =
   DataD [] name [] Nothing [RecC name (map mkVarBangType pairs)] deriveShowAndEQ
   where
     mkVarBangType (fieldName, fieldType) =
-      ( fieldName
-      , Bang NoSourceUnpackedness NoSourceStrictness
-      , fieldType
+      ( fieldName,
+        Bang NoSourceUnpackedness NoSourceStrictness,
+        fieldType
       )
 
-generateGetAllRecord
-  :: RecordGenerationParams
-  -> GenerationParams
-  -> I.Interface
-  -> Q [Dec]
+generateGetAllRecord ::
+  RecordGenerationParams ->
+  GenerationParams ->
+  I.Interface ->
+  Q [Dec]
 generateGetAllRecord
   RecordGenerationParams
-    { recordName = recordNameString
-    , recordPrefix = prefix
-    , recordTypeForName = getTypeForName
+    { recordName = recordNameString,
+      recordPrefix = prefix,
+      recordTypeForName = getTypeForName
     }
-  GenerationParams { getTHType = getArgType }
+  GenerationParams {getTHType = getArgType}
   I.Interface
-    { I.interfaceName = interfaceName
-    , I.interfaceProperties = properties
+    { I.interfaceName = interfaceName,
+      I.interfaceProperties = properties
     } = do
-  let theRecordName =
-        mkName $
-          maybe
-            (map Char.toUpper $ filter Char.isLetter $ Coerce.coerce interfaceName)
-            id
-            recordNameString
-      getPairFromProperty
-        I.Property { I.propertyName = propName, I.propertyType = propType } =
-          ( mkName $ prefix ++ propName
-          , Maybe.fromMaybe (getArgType propType) $
-              getTypeForName propName propType
-          )
-      getAllRecord =
-        buildDataFromNameTypePairs theRecordName $
-          map getPairFromProperty properties
-  pure [getAllRecord]
+    let theRecordName =
+          mkName $
+            Maybe.fromMaybe
+              (map Char.toUpper $ filter Char.isLetter $ Coerce.coerce interfaceName)
+              recordNameString
+        getPairFromProperty
+          I.Property {I.propertyName = propName, I.propertyType = propType} =
+            ( mkName $ prefix ++ propName,
+              Maybe.fromMaybe (getArgType propType) $
+                getTypeForName propName propType
+            )
+        getAllRecord =
+          buildDataFromNameTypePairs theRecordName $
+            map getPairFromProperty properties
+    pure [getAllRecord]
 
 getIntrospectionObjectFromFile :: FilePath -> ObjectPath -> Q I.Object
 getIntrospectionObjectFromFile filepath path = do
@@ -91,21 +93,21 @@ getIntrospectionObjectFromFile filepath path = do
     Nothing -> fail $ "Failed to parse DBus introspection XML: " <> filepath
     Just obj -> pure obj
 
-generateClientFromFile
-  :: RecordGenerationParams
-  -> GenerationParams
-  -> Bool
-  -> FilePath
-  -> Q [Dec]
+generateClientFromFile ::
+  RecordGenerationParams ->
+  GenerationParams ->
+  Bool ->
+  FilePath ->
+  Q [Dec]
 generateClientFromFile recordGenerationParams params useObjectPath filepath = do
   obj <- getIntrospectionObjectFromFile filepath "/"
   let actualObjectPath = I.objectPath obj
       realParams =
         if useObjectPath
-          then params { genObjectPath = Just actualObjectPath }
+          then params {genObjectPath = Just actualObjectPath}
           else params
       (<++>) = liftA2 (++)
   fmap concat $ forM (I.objectInterfaces obj) $ \interface -> do
-    generateGetAllRecord recordGenerationParams params interface <++>
-      generateClient realParams interface <++>
-      generateSignalsFromInterface realParams interface
+    generateGetAllRecord recordGenerationParams params interface
+      <++> generateClient realParams interface
+      <++> generateSignalsFromInterface realParams interface

--- a/packages/gtk-scaling-image/src/Graphics/UI/GIGtkScalingImage.hs
+++ b/packages/gtk-scaling-image/src/Graphics/UI/GIGtkScalingImage.hs
@@ -16,6 +16,7 @@ module Graphics.UI.GIGtkScalingImage
   )
 where
 
+import Control.Applicative ((<|>))
 import qualified Control.Concurrent.MVar as MV
 import Control.Monad
 import Control.Monad.IO.Class
@@ -262,7 +263,7 @@ autoFillImage drawArea getPixbuf orientation = liftIO $ do
             then getPixbuf requestSize
             else pure Nothing
 
-        let src = maybe (afSourcePixbuf old) Just srcFresh
+        let src = srcFresh <|> afSourcePixbuf old
             needsRefit =
               force
                 || requestSize /= afRequestSize old

--- a/packages/gtk-sni-tray/Setup.hs
+++ b/packages/gtk-sni-tray/Setup.hs
@@ -1,21 +1,24 @@
-import Distribution.Simple
-import Distribution.Simple.Setup (ConfigFlags(..), fromFlagOrDefault)
-import Distribution.Verbosity (Verbosity, normal)
-import Distribution.Simple.Utils (die')
-import System.Exit (ExitCode(..))
-import System.Process (readProcessWithExitCode)
-import Control.Exception (try, IOException)
+{-# LANGUAGE TupleSections #-}
+
+import Control.Exception (IOException, try)
 import Data.List (intercalate)
 import Data.Maybe (isJust)
+import Distribution.Simple
+import Distribution.Simple.Setup (ConfigFlags (..), fromFlagOrDefault)
+import Distribution.Simple.Utils (die')
+import Distribution.Verbosity (Verbosity, normal)
 import System.Environment (lookupEnv)
+import System.Exit (ExitCode (..))
+import System.Process (readProcessWithExitCode)
 
 main :: IO ()
 main =
-  defaultMainWithHooks simpleUserHooks
-    { confHook = \pkg flags -> do
-        preflightPkgConfig (fromFlagOrDefault normal (configVerbosity flags))
-        confHook simpleUserHooks pkg flags
-    }
+  defaultMainWithHooks
+    simpleUserHooks
+      { confHook = \pkg flags -> do
+          preflightPkgConfig (fromFlagOrDefault normal (configVerbosity flags))
+          confHook simpleUserHooks pkg flags
+      }
 
 preflightPkgConfig :: Verbosity -> IO ()
 preflightPkgConfig verbosity = do
@@ -26,29 +29,32 @@ preflightPkgConfig verbosity = do
   -- gtk-layer-shell on Wayland, but we don't want to prevent building the
   -- library when that optional dependency is unavailable.
   let required = ["gtk+-3.0"]
-  present <- mapM (\p -> (\ok -> (p, ok)) <$> pkgConfigExists p) required
+  present <- mapM (\p -> (p,) <$> pkgConfigExists p) required
   let missing = [p | (p, ok) <- present, not ok]
   if null missing
-  then pure ()
-  else do
-    inDirenv <- isJust <$> lookupEnv "DIRENV_DIR"
-    let nixHint =
-          if inDirenv
-          then "If you just changed Nix inputs, try: `direnv reload`"
-          else intercalate " " [ "If you're using Nix, enter the dev shell:"
-                               , "`nix develop` (or `direnv allow` + `direnv reload`)."
-                               ]
-        msg = unlines
-          [ "Missing system dependencies required via pkg-config:"
-          , "  " ++ intercalate ", " missing
-          , ""
-          , "This package needs `pkg-config` to find its C dependencies."
-          , "If you are building the standalone executable for Wayland, you will also need: gtk-layer-shell-0"
-          , ""
-          , nixHint
-          , "Otherwise, install the development packages for your distro (and pkg-config)."
-          ]
-    die' verbosity msg
+    then pure ()
+    else do
+      inDirenv <- isJust <$> lookupEnv "DIRENV_DIR"
+      let nixHint =
+            if inDirenv
+              then "If you just changed Nix inputs, try: `direnv reload`"
+              else
+                unwords
+                  [ "If you're using Nix, enter the dev shell:",
+                    "`nix develop` (or `direnv allow` + `direnv reload`)."
+                  ]
+          msg =
+            unlines
+              [ "Missing system dependencies required via pkg-config:",
+                "  " ++ intercalate ", " missing,
+                "",
+                "This package needs `pkg-config` to find its C dependencies.",
+                "If you are building the standalone executable for Wayland, you will also need: gtk-layer-shell-0",
+                "",
+                nixHint,
+                "Otherwise, install the development packages for your distro (and pkg-config)."
+              ]
+      die' verbosity msg
 
 pkgConfigExists :: String -> IO Bool
 pkgConfigExists name = do

--- a/packages/gtk-sni-tray/app/Main.hs
+++ b/packages/gtk-sni-tray/app/Main.hs
@@ -4,7 +4,7 @@
 module Main where
 
 import Control.Monad
-import qualified DBus as DBus
+import qualified DBus
 import DBus.Client
 import Data.Char (toLower)
 import Data.Int
@@ -115,7 +115,9 @@ setupLayerShellWindow
   reserveSpace = do
     supported <- GtkLayerShell.isSupported
     unless supported $
-      logM "StatusNotifier.StandaloneWindow" WARNING $
+      logM
+        "StatusNotifier.StandaloneWindow"
+        WARNING
         "Wayland detected, but gtk-layer-shell is not supported; falling back to a regular toplevel window"
     when supported $ do
       Gtk.windowSetDecorated window False
@@ -211,7 +213,7 @@ setupLayerShellWindow
                       ExactSize h -> h
                       ScreenRatio p ->
                         floor $ p * fromIntegral availableHeight
-                  clampNonNegative x = if x < 0 then 0 else x
+                  clampNonNegative x = max x 0
                   centerOffset availSize size =
                     clampNonNegative $ (availSize - size) `div` 2
                   endOffset availSize size =
@@ -623,10 +625,14 @@ buildWindows
     logRuntimeInfo backendChoice backend
     watcherPresent <- hasStatusNotifierWatcher client
     unless watcherPresent $ do
-      logM "StatusNotifier" WARNING $
+      logM
+        "StatusNotifier"
+        WARNING
         "No StatusNotifierWatcher found on D-Bus (org.kde.StatusNotifierWatcher). Tray will likely be empty."
       unless startWatcher $
-        logM "StatusNotifier" WARNING $
+        logM
+          "StatusNotifier"
+          WARNING
           "Start a watcher first (recommended) or run with --watcher to start one in-process."
     _ <- getRootLogger
     pid <- getProcessID
@@ -722,7 +728,7 @@ buildWindows
           Gtk.windowSetTypeHint window Gdk.WindowTypeHintDock
           case backend of
             BackendX11 ->
-              when (not noStrut) $ setupStrutWindow config window
+              unless noStrut $ setupStrutWindow config window
             BackendWayland ->
               setupLayerShellWindow config window (not noStrut)
           maybe

--- a/packages/gtk-sni-tray/src/StatusNotifier/Icon/Pixbuf.hs
+++ b/packages/gtk-sni-tray/src/StatusNotifier/Icon/Pixbuf.hs
@@ -112,10 +112,10 @@ recolorInPlace pb computeRgb = do
       validFormat = bytesPerPixel == 3 || bytesPerPixel == 4
 
       readChannel :: Ptr Word8 -> Int -> IO Word8
-      readChannel p off = peekByteOff p off
+      readChannel = peekByteOff
 
       writeChannel :: Ptr Word8 -> Int -> Word8 -> IO ()
-      writeChannel p off v = pokeByteOff p off v
+      writeChannel = pokeByteOff
 
   if width <= 0 || height <= 0 || not validFormat || BS.null pixelsBs
     then pure ()

--- a/packages/gtk-sni-tray/src/StatusNotifier/TransparentWindow.hs
+++ b/packages/gtk-sni-tray/src/StatusNotifier/TransparentWindow.hs
@@ -1,7 +1,10 @@
-{-# LANGUAGE OverloadedLabels #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
 -----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+
 -- |
 -- Module      : StatusNotifier.TransparentWindow
 -- Copyright   : (c) Ivan A. Malison
@@ -13,16 +16,15 @@
 --
 -- Make a window transparent. Approach adapted from python code from
 -- https://stackoverflow.com/questions/3908565/how-to-make-gtk-window-background-transparent/33294727#33294727
------------------------------------------------------------------------------
 module StatusNotifier.TransparentWindow where
 
-import           Control.Monad.IO.Class
-import           GI.Cairo.Render
-import           GI.Cairo.Render.Connector
+import Control.Monad.IO.Class
+import GI.Cairo.Render
+import GI.Cairo.Render.Connector
 import qualified GI.Gdk as Gdk
 import qualified GI.Gtk as Gtk
 
-makeWindowTransparent :: MonadIO m => Gtk.Window -> m ()
+makeWindowTransparent :: (MonadIO m) => Gtk.Window -> m ()
 makeWindowTransparent window = do
   screen <- Gtk.widgetGetScreen window
   visual <- Gdk.screenGetRgbaVisual screen

--- a/packages/gtk-sni-tray/src/StatusNotifier/Tray.hs
+++ b/packages/gtk-sni-tray/src/StatusNotifier/Tray.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module StatusNotifier.Tray where
@@ -183,8 +183,8 @@ getIconPixbufByName size name themePath = do
       maybeFile <-
         if fileExists
           then return $ Just nameString
-          else fmap join $ sequenceA $ getIconPathFromThemePath nameString <$> themePath
-      fmap join $ sequenceA $ safePixbufNewFromFile <$> maybeFile
+          else join <$> traverse (getIconPathFromThemePath nameString) themePath
+      join <$> traverse safePixbufNewFromFile maybeFile
 
 getIconPathFromThemePath :: String -> String -> IO (Maybe String)
 getIconPathFromThemePath name themePath =
@@ -249,7 +249,7 @@ data TrayClickDecision
 
 type TrayClickHook = TrayClickContext -> IO TrayClickDecision
 
-data TrayEventHooks = TrayEventHooks
+newtype TrayEventHooks = TrayEventHooks
   { trayClickHook :: Maybe TrayClickHook
   }
 
@@ -263,7 +263,7 @@ data TrayItemMatcher = TrayItemMatcher
     trayItemMatcherPredicate :: ItemInfo -> Bool
   }
 
-data TrayPriorityConfig = TrayPriorityConfig
+newtype TrayPriorityConfig = TrayPriorityConfig
   { trayPriorityMatchers :: [TrayItemMatcher]
   }
 
@@ -319,11 +319,11 @@ mkTrayItemMatcher = TrayItemMatcher
 
 trayMatchAny :: [TrayItemMatcher] -> TrayItemMatcher
 trayMatchAny matchers = mkTrayItemMatcher "any" $ \info ->
-  any (\matcher -> trayItemMatcherPredicate matcher info) matchers
+  any (`trayItemMatcherPredicate` info) matchers
 
 trayMatchAll :: [TrayItemMatcher] -> TrayItemMatcher
 trayMatchAll matchers = mkTrayItemMatcher "all" $ \info ->
-  all (\matcher -> trayItemMatcherPredicate matcher info) matchers
+  all (`trayItemMatcherPredicate` info) matchers
 
 trayMatchNot :: TrayItemMatcher -> TrayItemMatcher
 trayMatchNot matcher =
@@ -577,9 +577,9 @@ buildTray
           getPriorityIndex info =
             fromMaybe
               (length priorityMatchers)
-              (findIndex (\matcher -> trayItemMatcherPredicate matcher info) priorityMatchers)
+              (findIndex (`trayItemMatcherPredicate` info) priorityMatchers)
 
-          reorderTrayByPriority = when (not (null priorityMatchers)) $ do
+          reorderTrayByPriority = unless (null priorityMatchers) $ do
             infoMap <- getInfoMap
             let orderedInfos =
                   sortOn
@@ -770,7 +770,7 @@ buildTray
                                       popupGtkMenu gtkMenu currentEvent
                                       return False
                           traverse_
-                            ( \action -> case action of
+                            ( \case
                                 Activate ->
                                   runAsync "Activate" $
                                     void $
@@ -860,12 +860,9 @@ buildTray
                             ( \d ->
                                 catchAny
                                   (void $ IC.scroll client serviceName servicePath delta d)
-                                  ( \e ->
-                                      trayLogger WARNING $
-                                        printf
-                                          "Scroll failed for %s: %s"
-                                          (coerce serviceName :: String)
-                                          (show e)
+                                  ( trayLogger WARNING
+                                      . printf "Scroll failed for %s: %s" (coerce serviceName :: String)
+                                      . show
                                   )
                             )
                             direction'

--- a/packages/gtk-strut/Setup.hs
+++ b/packages/gtk-strut/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/packages/gtk-strut/src/Graphics/UI/EWMHStrut.hs
+++ b/packages/gtk-strut/src/Graphics/UI/EWMHStrut.hs
@@ -1,121 +1,132 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module Graphics.UI.EWMHStrut where
 
-import           Control.Monad.IO.Class
-import           Data.Int
-import           Data.Text
-import           Data.Word
-import           Foreign.C.Types
-import           Foreign.Marshal.Array
-import           Foreign.Ptr
-import           Foreign.Storable
-
+import Control.Monad.IO.Class
+import Data.Int
+import Data.Text
+import Data.Word
+import Foreign.C.Types
+import Foreign.Marshal.Array
+import Foreign.Ptr
+import Foreign.Storable
 import qualified GI.Gdk as Gdk
 
 data EWMHStrutSettings = EWMHStrutSettings
-  { _left :: Int32
-  , _right :: Int32
-  , _top :: Int32
-  , _bottom :: Int32
-  , _left_start_y :: Int32
-  , _left_end_y :: Int32
-  , _right_start_y :: Int32
-  , _right_end_y :: Int32
-  , _top_start_x :: Int32
-  , _top_end_x :: Int32
-  , _bottom_start_x :: Int32
-  , _bottom_end_x :: Int32
-  } deriving (Show, Eq)
-
-zeroStrutSettings = EWMHStrutSettings
-  { _left = 0
-  , _right = 0
-  , _top = 0
-  , _bottom = 0
-  , _left_start_y = 0
-  , _left_end_y = 0
-  , _right_start_y = 0
-  , _right_end_y = 0
-  , _top_start_x = 0
-  , _top_end_x = 0
-  , _bottom_start_x = 0
-  , _bottom_end_x = 0
+  { _left :: Int32,
+    _right :: Int32,
+    _top :: Int32,
+    _bottom :: Int32,
+    _left_start_y :: Int32,
+    _left_end_y :: Int32,
+    _right_start_y :: Int32,
+    _right_end_y :: Int32,
+    _top_start_x :: Int32,
+    _top_end_x :: Int32,
+    _bottom_start_x :: Int32,
+    _bottom_end_x :: Int32
   }
+  deriving (Show, Eq)
+
+zeroStrutSettings =
+  EWMHStrutSettings
+    { _left = 0,
+      _right = 0,
+      _top = 0,
+      _bottom = 0,
+      _left_start_y = 0,
+      _left_end_y = 0,
+      _right_start_y = 0,
+      _right_end_y = 0,
+      _top_start_x = 0,
+      _top_end_x = 0,
+      _bottom_start_x = 0,
+      _bottom_end_x = 0
+    }
 
 scaleStrutSettings :: Int32 -> EWMHStrutSettings -> EWMHStrutSettings
-scaleStrutSettings scaleFactor st = st
-  { _left = _left st * scaleFactor
-  , _right = _right st * scaleFactor
-  , _top = _top st * scaleFactor
-  , _bottom = _bottom st * scaleFactor
-  , _left_start_y = _left_start_y st * scaleFactor
-  , _left_end_y = _left_end_y st * scaleFactor
-  , _right_start_y = _right_start_y st * scaleFactor
-  , _right_end_y = _right_end_y st * scaleFactor
-  , _top_start_x = _top_start_x st * scaleFactor
-  , _top_end_x = _top_end_x st * scaleFactor
-  , _bottom_start_x = _bottom_start_x st * scaleFactor
-  , _bottom_end_x = _bottom_end_x st * scaleFactor
-  }
+scaleStrutSettings scaleFactor st =
+  st
+    { _left = _left st * scaleFactor,
+      _right = _right st * scaleFactor,
+      _top = _top st * scaleFactor,
+      _bottom = _bottom st * scaleFactor,
+      _left_start_y = _left_start_y st * scaleFactor,
+      _left_end_y = _left_end_y st * scaleFactor,
+      _right_start_y = _right_start_y st * scaleFactor,
+      _right_end_y = _right_end_y st * scaleFactor,
+      _top_start_x = _top_start_x st * scaleFactor,
+      _top_end_x = _top_end_x st * scaleFactor,
+      _bottom_start_x = _bottom_start_x st * scaleFactor,
+      _bottom_end_x = _bottom_end_x st * scaleFactor
+    }
 
-strutSettingsToPtr :: MonadIO m => EWMHStrutSettings -> m (Ptr CULong)
-strutSettingsToPtr EWMHStrutSettings
-                     { _left = left
-                     , _right = right
-                     , _top = top
-                     , _bottom = bottom
-                     , _left_start_y = left_start_y
-                     , _left_end_y = left_end_y
-                     , _right_start_y = right_start_y
-                     , _right_end_y = right_end_y
-                     , _top_start_x = top_start_x
-                     , _top_end_x = top_end_x
-                     , _bottom_start_x = bottom_start_x
-                     , _bottom_end_x = bottom_end_x
-                     } = liftIO $ do
-  arr <- mallocArray 12
-  let doPoke off v = pokeElemOff arr off $ fromIntegral v
-  doPoke 0 left
-  doPoke 1 right
-  doPoke 2 top
-  doPoke 3 bottom
-  doPoke 4 left_start_y
-  doPoke 5 left_end_y
-  doPoke 6 right_start_y
-  doPoke 7 right_end_y
-  doPoke 8 top_start_x
-  doPoke 9 top_end_x
-  doPoke 10 bottom_start_x
-  doPoke 11 bottom_end_x
-  return arr
+strutSettingsToPtr :: (MonadIO m) => EWMHStrutSettings -> m (Ptr CULong)
+strutSettingsToPtr
+  EWMHStrutSettings
+    { _left = left,
+      _right = right,
+      _top = top,
+      _bottom = bottom,
+      _left_start_y = left_start_y,
+      _left_end_y = left_end_y,
+      _right_start_y = right_start_y,
+      _right_end_y = right_end_y,
+      _top_start_x = top_start_x,
+      _top_end_x = top_end_x,
+      _bottom_start_x = bottom_start_x,
+      _bottom_end_x = bottom_end_x
+    } = liftIO $ do
+    arr <- mallocArray 12
+    let doPoke off v = pokeElemOff arr off $ fromIntegral v
+    doPoke 0 left
+    doPoke 1 right
+    doPoke 2 top
+    doPoke 3 bottom
+    doPoke 4 left_start_y
+    doPoke 5 left_end_y
+    doPoke 6 right_start_y
+    doPoke 7 right_end_y
+    doPoke 8 top_start_x
+    doPoke 9 top_end_x
+    doPoke 10 bottom_start_x
+    doPoke 11 bottom_end_x
+    return arr
 
-foreign import ccall "gdk_property_change" gdk_property_change ::
-  Ptr Gdk.Window ->
-    Ptr Gdk.Atom -> Ptr Gdk.Atom -> Int32 -> CUInt -> Ptr CUChar -> Int32 -> IO ()
+foreign import ccall "gdk_property_change"
+  gdk_property_change ::
+    Ptr Gdk.Window ->
+    Ptr Gdk.Atom ->
+    Ptr Gdk.Atom ->
+    Int32 ->
+    CUInt ->
+    Ptr CUChar ->
+    Int32 ->
+    IO ()
 
-propertyChange
-  :: (Gdk.IsWindow a, MonadIO m)
-  => a
-  -> Gdk.Atom
-  -> Gdk.Atom
-  -> Int32
-  -> Gdk.PropMode
-  -> Ptr CUChar
-  -> Int32
-  -> m ()
+propertyChange ::
+  (Gdk.IsWindow a, MonadIO m) =>
+  a ->
+  Gdk.Atom ->
+  Gdk.Atom ->
+  Int32 ->
+  Gdk.PropMode ->
+  Ptr CUChar ->
+  Int32 ->
+  m ()
 propertyChange window property type_ format mode data_ nelements = liftIO $ do
-    window' <- Gdk.unsafeManagedPtrCastPtr window
-    property' <- Gdk.unsafeManagedPtrGetPtr property
-    type_' <- Gdk.unsafeManagedPtrGetPtr type_
-    let mode' = (fromIntegral . fromEnum) mode
-    gdk_property_change window' property' type_' format mode' data_ nelements
-    Gdk.touchManagedPtr window
-    Gdk.touchManagedPtr property
-    Gdk.touchManagedPtr type_
-    return ()
+  window' <- Gdk.unsafeManagedPtrCastPtr window
+  property' <- Gdk.unsafeManagedPtrGetPtr property
+  type_' <- Gdk.unsafeManagedPtrGetPtr type_
+  let mode' = (fromIntegral . fromEnum) mode
+  gdk_property_change window' property' type_' format mode' data_ nelements
+  Gdk.touchManagedPtr window
+  Gdk.touchManagedPtr property
+  Gdk.touchManagedPtr type_
+  return ()
 
-setStrut :: MonadIO m => Gdk.IsWindow w => w -> EWMHStrutSettings -> m ()
+setStrut :: (MonadIO m) => (Gdk.IsWindow w) => w -> EWMHStrutSettings -> m ()
 setStrut w settings = do
   strutAtom <- Gdk.atomIntern "_NET_WM_STRUT_PARTIAL" False
   cardinalAtom <- Gdk.atomIntern "CARDINAL" False

--- a/packages/gtk-strut/src/Graphics/UI/GIGtkStrut.hs
+++ b/packages/gtk-strut/src/Graphics/UI/GIGtkStrut.hs
@@ -1,78 +1,87 @@
 module Graphics.UI.GIGtkStrut
-  ( defaultStrutConfig
-  , StrutPosition(..)
-  , StrutSize(..)
-  , StrutAlignment(..)
-  , StrutConfig(..)
-  , buildStrutWindow
-  , setupStrutWindow
-  ) where
+  ( defaultStrutConfig,
+    StrutPosition (..),
+    StrutSize (..),
+    StrutAlignment (..),
+    StrutConfig (..),
+    buildStrutWindow,
+    setupStrutWindow,
+  )
+where
 
-import           Control.Monad
-import           Control.Monad.Fail (MonadFail)
-import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Maybe
-import           Data.Default
-import           Data.Int
-import           Data.Maybe
+import Control.Monad
+import Control.Monad.Fail (MonadFail)
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Maybe
+import Data.Default
+import Data.IORef
+import Data.Int
+import Data.Maybe
 import qualified Data.Text as T
 import qualified GI.Gdk as Gdk
 import qualified GI.Gtk as Gtk
-import           Graphics.UI.EWMHStrut
-import           System.Log.Logger
-import           Text.Printf
+import Graphics.UI.EWMHStrut
+import System.Log.Logger
+import Text.Printf
 
-strutLog :: MonadIO m => Priority -> String -> m ()
+strutLog :: (MonadIO m) => Priority -> String -> m ()
 strutLog p s = liftIO $ logM "Graphics.UI.GIGtkStrut" p s
 
 data StrutPosition
-  = TopPos | BottomPos | LeftPos | RightPos
-    deriving (Show, Read, Eq)
+  = TopPos
+  | BottomPos
+  | LeftPos
+  | RightPos
+  deriving (Show, Read, Eq)
 
 data StrutAlignment
-  = Beginning | Center | End
-    deriving (Show, Read, Eq)
+  = Beginning
+  | Center
+  | End
+  deriving (Show, Read, Eq)
 
 data StrutSize
-  = ExactSize Int32 | ScreenRatio Rational
-    deriving (Show, Read, Eq)
+  = ExactSize Int32
+  | ScreenRatio Rational
+  deriving (Show, Read, Eq)
 
 data StrutConfig = StrutConfig
-  { strutWidth :: StrutSize
-  , strutHeight :: StrutSize
-  , strutXPadding :: Int32
-  , strutYPadding :: Int32
-  , strutMonitor :: Maybe Int32
-  , strutPosition :: StrutPosition
-  , strutAlignment :: StrutAlignment
-  , strutDisplayName :: Maybe T.Text
-  } deriving (Show, Eq)
-
-defaultStrutConfig = StrutConfig
-  { strutWidth = ScreenRatio 1
-  , strutHeight = ScreenRatio 1
-  , strutXPadding = 0
-  , strutYPadding = 0
-  , strutMonitor = Nothing
-  , strutPosition = TopPos
-  , strutAlignment = Beginning
-  , strutDisplayName = Nothing
+  { strutWidth :: StrutSize,
+    strutHeight :: StrutSize,
+    strutXPadding :: Int32,
+    strutYPadding :: Int32,
+    strutMonitor :: Maybe Int32,
+    strutPosition :: StrutPosition,
+    strutAlignment :: StrutAlignment,
+    strutDisplayName :: Maybe T.Text
   }
+  deriving (Show, Eq)
+
+defaultStrutConfig =
+  StrutConfig
+    { strutWidth = ScreenRatio 1,
+      strutHeight = ScreenRatio 1,
+      strutXPadding = 0,
+      strutYPadding = 0,
+      strutMonitor = Nothing,
+      strutPosition = TopPos,
+      strutAlignment = Beginning,
+      strutDisplayName = Nothing
+    }
 
 instance Default StrutConfig where
   def =
     StrutConfig
-    { strutWidth = ScreenRatio 1
-    , strutHeight = ScreenRatio 1
-    , strutXPadding = 0
-    , strutYPadding = 0
-    , strutMonitor = Nothing
-    , strutPosition = TopPos
-    , strutAlignment = Beginning
-    , strutDisplayName = Nothing
-    }
-
+      { strutWidth = ScreenRatio 1,
+        strutHeight = ScreenRatio 1,
+        strutXPadding = 0,
+        strutYPadding = 0,
+        strutMonitor = Nothing,
+        strutPosition = TopPos,
+        strutAlignment = Beginning,
+        strutDisplayName = Nothing
+      }
 
 -- | Build a strut window to the specifications provided by the 'StrutConfig'
 -- argument.
@@ -85,146 +94,175 @@ buildStrutWindow config = do
 -- | Configure the provided 'Gtk.Window' so that it has the properties specified
 -- by the 'StrutConfig' argument.
 setupStrutWindow :: (MonadFail m, MonadIO m) => StrutConfig -> Gtk.Window -> m ()
-setupStrutWindow StrutConfig
-                   { strutWidth = widthSize
-                   , strutHeight = heightSize
-                   , strutXPadding = xpadding
-                   , strutYPadding = ypadding
-                   , strutMonitor = monitorNumber
-                   , strutPosition = position
-                   , strutAlignment = alignment
-                   , strutDisplayName = displayName
-                   } window = do
-  strutLog DEBUG "Starting strut window setup"
-  Just display <- maybe Gdk.displayGetDefault Gdk.displayOpen displayName
-  Just monitor <- maybe (Gdk.displayGetPrimaryMonitor display)
-                  (Gdk.displayGetMonitor display) monitorNumber
+setupStrutWindow
+  StrutConfig
+    { strutWidth = widthSize,
+      strutHeight = heightSize,
+      strutXPadding = xpadding,
+      strutYPadding = ypadding,
+      strutMonitor = monitorNumber,
+      strutPosition = position,
+      strutAlignment = alignment,
+      strutDisplayName = displayName
+    }
+  window = do
+    strutLog DEBUG "Starting strut window setup"
+    Just display <- maybe Gdk.displayGetDefault Gdk.displayOpen displayName
+    Just monitor <-
+      maybe
+        (Gdk.displayGetPrimaryMonitor display)
+        (Gdk.displayGetMonitor display)
+        monitorNumber
 
-  screen <- Gdk.displayGetDefaultScreen display
+    screen <- Gdk.displayGetDefaultScreen display
 
-  monitorCount <- Gdk.displayGetNMonitors display
-  allMonitors <- catMaybes <$> mapM (Gdk.displayGetMonitor display)
-                 [0..(monitorCount-1)]
-  allGeometries <- mapM Gdk.monitorGetGeometry allMonitors
+    monitorCount <- Gdk.displayGetNMonitors display
+    allMonitors <-
+      catMaybes
+        <$> mapM
+          (Gdk.displayGetMonitor display)
+          [0 .. (monitorCount - 1)]
+    allGeometries <- mapM Gdk.monitorGetGeometry allMonitors
 
-  let getFullY geometry = (+) <$> Gdk.getRectangleY geometry
-                              <*> Gdk.getRectangleHeight geometry
-      getFullX geometry = (+) <$> Gdk.getRectangleX geometry
-                              <*> Gdk.getRectangleWidth geometry
+    let getFullY geometry =
+          (+)
+            <$> Gdk.getRectangleY geometry
+            <*> Gdk.getRectangleHeight geometry
+        getFullX geometry =
+          (+)
+            <$> Gdk.getRectangleX geometry
+            <*> Gdk.getRectangleWidth geometry
 
-  -- The screen concept actually encapsulates things displayed across multiple
-  -- monitors, which is why we take the maximum here -- what we really want to
-  -- know is what is the farthest we can go in each direction on any monitor.
-  screenWidth <- maximum <$> mapM getFullX allGeometries
-  screenHeight <- maximum <$> mapM getFullY allGeometries
+    -- The screen concept actually encapsulates things displayed across multiple
+    -- monitors, which is why we take the maximum here -- what we really want to
+    -- know is what is the farthest we can go in each direction on any monitor.
+    screenWidth <- maximum <$> mapM getFullX allGeometries
+    screenHeight <- maximum <$> mapM getFullY allGeometries
 
-  geometry <- Gdk.newZeroGeometry
+    geometry <- Gdk.newZeroGeometry
 
-  monitorGeometry <- Gdk.monitorGetGeometry monitor
-  monitorScaleFactor <- Gdk.monitorGetScaleFactor monitor
-  monitorWidth <- Gdk.getRectangleWidth monitorGeometry
-  monitorHeight <- Gdk.getRectangleHeight monitorGeometry
-  monitorX <- Gdk.getRectangleX monitorGeometry
-  monitorY <- Gdk.getRectangleY monitorGeometry
+    monitorGeometry <- Gdk.monitorGetGeometry monitor
+    monitorScaleFactor <- Gdk.monitorGetScaleFactor monitor
+    monitorWidth <- Gdk.getRectangleWidth monitorGeometry
+    monitorHeight <- Gdk.getRectangleHeight monitorGeometry
+    monitorX <- Gdk.getRectangleX monitorGeometry
+    monitorY <- Gdk.getRectangleY monitorGeometry
 
-  let width =
-        case widthSize of
-          ExactSize w -> w
-          ScreenRatio p ->
-            floor $ p * fromIntegral (monitorWidth - (2 * xpadding))
-      height =
-        case heightSize of
-          ExactSize h -> h
-          ScreenRatio p ->
-            floor $ p * fromIntegral (monitorHeight - (2 * ypadding))
+    let width =
+          case widthSize of
+            ExactSize w -> w
+            ScreenRatio p ->
+              floor $ p * fromIntegral (monitorWidth - (2 * xpadding))
+        height =
+          case heightSize of
+            ExactSize h -> h
+            ScreenRatio p ->
+              floor $ p * fromIntegral (monitorHeight - (2 * ypadding))
 
-  Gdk.setGeometryBaseWidth geometry width
-  Gdk.setGeometryBaseHeight geometry height
-  Gdk.setGeometryMinWidth geometry width
-  Gdk.setGeometryMinHeight geometry height
-  Gdk.setGeometryMaxWidth geometry width
-  Gdk.setGeometryMaxHeight geometry height
-  Gtk.windowSetGeometryHints window (Nothing :: Maybe Gtk.Window)
-       (Just geometry) allHints
+    Gdk.setGeometryBaseWidth geometry width
+    Gdk.setGeometryBaseHeight geometry height
+    Gdk.setGeometryMinWidth geometry width
+    Gdk.setGeometryMinHeight geometry height
+    Gdk.setGeometryMaxWidth geometry width
+    Gdk.setGeometryMaxHeight geometry height
+    Gtk.windowSetGeometryHints
+      window
+      (Nothing :: Maybe Gtk.Window)
+      (Just geometry)
+      allHints
 
-  let paddedHeight = height + 2 * ypadding
-      paddedWidth = width + 2 * xpadding
-      getAlignedPos dimensionPos dpadding monitorSize barSize =
-        dimensionPos +
-        case alignment of
-          Beginning -> dpadding
-          Center -> (monitorSize - barSize) `div` 2
-          End -> monitorSize - barSize - dpadding
-      xAligned = getAlignedPos monitorX xpadding monitorWidth width
-      yAligned = getAlignedPos monitorY ypadding monitorHeight height
-      (xPos, yPos) =
-        case position of
-          TopPos -> (xAligned, monitorY + ypadding)
-          BottomPos -> (xAligned, monitorY + monitorHeight - height - ypadding)
-          LeftPos -> (monitorX + xpadding, yAligned)
-          RightPos -> (monitorX + monitorWidth - width - xpadding, yAligned)
+    let paddedHeight = height + 2 * ypadding
+        paddedWidth = width + 2 * xpadding
+        getAlignedPos dimensionPos dpadding monitorSize barSize =
+          dimensionPos
+            + case alignment of
+              Beginning -> dpadding
+              Center -> (monitorSize - barSize) `div` 2
+              End -> monitorSize - barSize - dpadding
+        xAligned = getAlignedPos monitorX xpadding monitorWidth width
+        yAligned = getAlignedPos monitorY ypadding monitorHeight height
+        (xPos, yPos) =
+          case position of
+            TopPos -> (xAligned, monitorY + ypadding)
+            BottomPos -> (xAligned, monitorY + monitorHeight - height - ypadding)
+            LeftPos -> (monitorX + xpadding, yAligned)
+            RightPos -> (monitorX + monitorWidth - width - xpadding, yAligned)
 
-  Gtk.windowSetTypeHint window Gdk.WindowTypeHintDock
-  Gtk.windowSetScreen window screen
-  Gtk.windowMove window xPos yPos
-  Gtk.windowSetKeepBelow window True
+    Gtk.windowSetTypeHint window Gdk.WindowTypeHintDock
+    Gtk.windowSetScreen window screen
+    Gtk.windowMove window xPos yPos
+    Gtk.windowSetKeepBelow window True
 
-  let ewmhSettings =
-        case position of
-          TopPos ->
-            zeroStrutSettings
-            { _top = monitorY + paddedHeight
-            , _top_start_x = xPos - xpadding
-            , _top_end_x = xPos + width + xpadding - 1
-            }
-          BottomPos ->
-            zeroStrutSettings
-            { _bottom = screenHeight - monitorY - monitorHeight + paddedHeight
-            , _bottom_start_x = xPos - xpadding
-            , _bottom_end_x = xPos + width + xpadding - 1
-            }
-          LeftPos ->
-            zeroStrutSettings
-            { _left = monitorX + paddedWidth
-            , _left_start_y = yPos - ypadding
-            , _left_end_y = yPos + height + ypadding - 1
-            }
-          RightPos ->
-            zeroStrutSettings
-            { _right = screenWidth - monitorX - monitorWidth + paddedWidth
-            , _right_start_y = yPos - ypadding
-            , _right_end_y = yPos + height + ypadding - 1
-            }
-      scaledStrutSettings = scaleStrutSettings monitorScaleFactor ewmhSettings
-      setStrutProperties =
-        void $ runMaybeT $ do
-          gdkWindow <- MaybeT $ Gtk.widgetGetWindow window
-          lift $ setStrut gdkWindow scaledStrutSettings
-      logPairs =
-        [ ("width", show width)
-        , ("height", show height)
-        , ("xPos", show xPos)
-        , ("yPos", show yPos)
-        , ("paddedWidth", show paddedWidth)
-        , ("paddedHeight", show paddedHeight)
-        , ("monitorWidth", show monitorWidth)
-        , ("monitorHeight", show monitorHeight)
-        , ("monitorX", show monitorX)
-        , ("monitorY", show monitorY)
-        , ("strutSettings", show ewmhSettings)
-        , ("scaledStrutSettings", show scaledStrutSettings)
-        ]
+    let makeEWMHSettings actualWidth actualHeight =
+          case position of
+            TopPos ->
+              zeroStrutSettings
+                { _top = monitorY + actualHeight + 2 * ypadding,
+                  _top_start_x = xPos - xpadding,
+                  _top_end_x = xPos + actualWidth + xpadding - 1
+                }
+            BottomPos ->
+              zeroStrutSettings
+                { _bottom = screenHeight - monitorY - monitorHeight + actualHeight + 2 * ypadding,
+                  _bottom_start_x = xPos - xpadding,
+                  _bottom_end_x = xPos + actualWidth + xpadding - 1
+                }
+            LeftPos ->
+              zeroStrutSettings
+                { _left = monitorX + actualWidth + 2 * xpadding,
+                  _left_start_y = yPos - ypadding,
+                  _left_end_y = yPos + actualHeight + ypadding - 1
+                }
+            RightPos ->
+              zeroStrutSettings
+                { _right = screenWidth - monitorX - monitorWidth + actualWidth + 2 * xpadding,
+                  _right_start_y = yPos - ypadding,
+                  _right_end_y = yPos + actualHeight + ypadding - 1
+                }
+        ewmhSettings = makeEWMHSettings width height
+        scaledStrutSettings = scaleStrutSettings monitorScaleFactor ewmhSettings
+        setStrutProperties settings =
+          void $ runMaybeT $ do
+            gdkWindow <- MaybeT $ Gtk.widgetGetWindow window
+            lift $ setStrut gdkWindow settings
+        logPairs =
+          [ ("width", show width),
+            ("height", show height),
+            ("xPos", show xPos),
+            ("yPos", show yPos),
+            ("paddedWidth", show paddedWidth),
+            ("paddedHeight", show paddedHeight),
+            ("monitorWidth", show monitorWidth),
+            ("monitorHeight", show monitorHeight),
+            ("monitorX", show monitorX),
+            ("monitorY", show monitorY),
+            ("strutSettings", show ewmhSettings),
+            ("scaledStrutSettings", show scaledStrutSettings)
+          ]
 
-  strutLog DEBUG "Properties:"
-  mapM_ (\(name, value) -> strutLog WARNING $ printf "%s: %s" name value) logPairs
+    strutLog DEBUG "Properties:"
+    mapM_ (\(name, value) -> strutLog WARNING $ printf "%s: %s" name value) logPairs
 
-  void $ Gtk.onWidgetRealize window setStrutProperties
+    lastStrutRef <- liftIO $ newIORef Nothing
+    let updateStrutProperties settings = liftIO $ do
+          let scaledSettings = scaleStrutSettings monitorScaleFactor settings
+          lastSettings <- readIORef lastStrutRef
+          when (lastSettings /= Just scaledSettings) $ do
+            strutLog DEBUG $ "Setting strut properties: " ++ show scaledSettings
+            writeIORef lastStrutRef $ Just scaledSettings
+            setStrutProperties scaledSettings
+
+    void $ Gtk.onWidgetRealize window $ updateStrutProperties ewmhSettings
+    void $ Gtk.onWidgetSizeAllocate window $ \allocation -> do
+      actualWidth <- Gdk.getRectangleWidth allocation
+      actualHeight <- Gdk.getRectangleHeight allocation
+      updateStrutProperties $ makeEWMHSettings actualWidth actualHeight
 
 allHints :: [Gdk.WindowHints]
 allHints =
-  [ Gdk.WindowHintsMinSize
-  , Gdk.WindowHintsMaxSize
-  , Gdk.WindowHintsBaseSize
-  , Gdk.WindowHintsUserPos
-  , Gdk.WindowHintsUserSize
+  [ Gdk.WindowHintsMinSize,
+    Gdk.WindowHintsMaxSize,
+    Gdk.WindowHintsBaseSize,
+    Gdk.WindowHintsUserPos,
+    Gdk.WindowHintsUserSize
   ]

--- a/packages/gtk-strut/src/Graphics/UI/GIGtkStrut.hs
+++ b/packages/gtk-strut/src/Graphics/UI/GIGtkStrut.hs
@@ -12,8 +12,6 @@ where
 import Control.Monad
 import Control.Monad.Fail (MonadFail)
 import Control.Monad.IO.Class
-import Control.Monad.Trans.Class
-import Control.Monad.Trans.Maybe
 import Data.Default
 import Data.IORef
 import Data.Int
@@ -221,10 +219,13 @@ setupStrutWindow
                 }
         ewmhSettings = makeEWMHSettings width height
         scaledStrutSettings = scaleStrutSettings monitorScaleFactor ewmhSettings
-        setStrutProperties settings =
-          void $ runMaybeT $ do
-            gdkWindow <- MaybeT $ Gtk.widgetGetWindow window
-            lift $ setStrut gdkWindow settings
+        setStrutProperties settings = do
+          mGdkWindow <- Gtk.widgetGetWindow window
+          case mGdkWindow of
+            Nothing -> pure False
+            Just gdkWindow -> do
+              setStrut gdkWindow settings
+              pure True
         logPairs =
           [ ("width", show width),
             ("height", show height),
@@ -249,14 +250,19 @@ setupStrutWindow
           lastSettings <- readIORef lastStrutRef
           when (lastSettings /= Just scaledSettings) $ do
             strutLog DEBUG $ "Setting strut properties: " ++ show scaledSettings
-            writeIORef lastStrutRef $ Just scaledSettings
-            setStrutProperties scaledSettings
+            didSet <- setStrutProperties scaledSettings
+            when didSet $
+              writeIORef lastStrutRef $
+                Just scaledSettings
 
     void $ Gtk.onWidgetRealize window $ updateStrutProperties ewmhSettings
     void $ Gtk.onWidgetSizeAllocate window $ \allocation -> do
       actualWidth <- Gdk.getRectangleWidth allocation
       actualHeight <- Gdk.getRectangleHeight allocation
-      updateStrutProperties $ makeEWMHSettings actualWidth actualHeight
+      updateStrutProperties $
+        makeEWMHSettings
+          actualWidth
+          actualHeight
 
 allHints :: [Gdk.WindowHints]
 allHints =

--- a/packages/status-notifier-item/Setup.hs
+++ b/packages/status-notifier-item/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/packages/status-notifier-item/item/Main.hs
+++ b/packages/status-notifier-item/item/Main.hs
@@ -9,40 +9,46 @@ import Paths_status_notifier_item (version)
 import StatusNotifier.Item.Service
 import Text.Printf
 
-itemsParamsParser = ItemParams
-  <$> strOption
-  (  long "icon-name"
-  <> short 'n'
-  <> metavar "NAME"
-  <> value "emacs"
-  <> help "The icon the item will display."
-  ) <*> strOption
-  (  long "overlay-name"
-  <> short 'o'
-  <> metavar "NAME"
-  <> value "steam"
-  <> help "The icon that will be used for the overlay."
-  ) <*> strOption
-  (  long "dbus-name"
-  <> short 'd'
-  <> metavar "NAME"
-  <> value "org.SampleSNI"
-  <> help "The dbus name used for this sample item."
-  )
+itemsParamsParser =
+  ItemParams
+    <$> strOption
+      ( long "icon-name"
+          <> short 'n'
+          <> metavar "NAME"
+          <> value "emacs"
+          <> help "The icon the item will display."
+      )
+    <*> strOption
+      ( long "overlay-name"
+          <> short 'o'
+          <> metavar "NAME"
+          <> value "steam"
+          <> help "The icon that will be used for the overlay."
+      )
+    <*> strOption
+      ( long "dbus-name"
+          <> short 'd'
+          <> metavar "NAME"
+          <> value "org.SampleSNI"
+          <> help "The dbus name used for this sample item."
+      )
 
 versionOption :: Parser (a -> a)
-versionOption = infoOption
-                (printf "status-notifier-item %s" $ showVersion version)
-                (  long "version"
-                <> help "Show the version number of gtk-sni-tray"
-                )
+versionOption =
+  infoOption
+    (printf "status-notifier-item %s" $ showVersion version)
+    ( long "version"
+        <> help "Show the version number of gtk-sni-tray"
+    )
 
 main :: IO ()
 main = do
-  itemParams <- execParser $ info (helper <*> versionOption <*> itemsParamsParser)
-                (  fullDesc
-                <> progDesc "Run a static StatusNotifierItem"
-                )
+  itemParams <-
+    execParser $
+      info
+        (helper <*> versionOption <*> itemsParamsParser)
+        ( fullDesc
+            <> progDesc "Run a static StatusNotifierItem"
+        )
   buildItem itemParams
-  void $ getChar
-
+  void getChar

--- a/packages/status-notifier-item/src/StatusNotifier/Host/Service.hs
+++ b/packages/status-notifier-item/src/StatusNotifier/Host/Service.hs
@@ -555,7 +555,7 @@ build
           let (failures, successes) = partitionEithers updateResults
               logLevel = propertyUpdateFailureLogLevel failures successes
           mapM_ (doUpdate updateType) $ catMaybes successes
-          when (not $ null failures) $
+          unless (null failures) $
             hostLogger logLevel $
               printf "Property update failures %s" $
                 show failures

--- a/packages/status-notifier-item/src/StatusNotifier/Item/Client.hs
+++ b/packages/status-notifier-item/src/StatusNotifier/Item/Client.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
 module StatusNotifier.Item.Client where
 
 import DBus.Generation
@@ -9,7 +10,8 @@ import System.FilePath
 
 generateClientFromFile
   defaultGenerationParams
-  { genTakeSignalErrorHandler = True }
+    { genTakeSignalErrorHandler = True
+    }
   False
   ("xml" </> "StatusNotifierItem.xml")
 

--- a/packages/status-notifier-item/src/StatusNotifier/Item/Service.hs
+++ b/packages/status-notifier-item/src/StatusNotifier/Item/Service.hs
@@ -1,41 +1,44 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module StatusNotifier.Item.Service where
 
-import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Except
-import           DBus
-import           DBus.Client
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Except
+import DBus
+import DBus.Client
 import qualified DBus.TH as DBusTH
 import qualified Data.ByteString as BS
-import           Data.Int
-import           Data.String
+import Data.Int
+import Data.String
 import qualified StatusNotifier.Watcher.Client as W
 
 data ItemParams = ItemParams
-  { iconName :: String
-  , iconOverlayName :: String
-  , itemDBusName :: String
-  } deriving (Eq, Show, Read)
+  { iconName :: String,
+    iconOverlayName :: String,
+    itemDBusName :: String
+  }
+  deriving (Eq, Show, Read)
 
-buildItem ItemParams
-            { iconName = name
-            , iconOverlayName = overlayName
-            , itemDBusName = dbusName
-            } = do
-  client <- connectSession
-  let
-    getTooltip :: IO (String, [(Int32, Int32, BS.ByteString)], String, String)
-    getTooltip = return ("", [], "Title", "Text")
-  let clientInterface =
-        Interface { interfaceName = "org.kde.StatusNotifierItem"
-                  , interfaceMethods = []
-                  , interfaceProperties =
-                    [ readOnlyProperty "IconName" $ return name
-                    , readOnlyProperty "OverlayIconName" $ return overlayName
-                    , readOnlyProperty "ToolTip" $ getTooltip
-                    ]
-                  , interfaceSignals = []
-                  }
-  export client (fromString "/StatusNotifierItem") clientInterface
-  requestName client (busName_ dbusName) []
-  W.registerStatusNotifierItem client dbusName
+buildItem
+  ItemParams
+    { iconName = name,
+      iconOverlayName = overlayName,
+      itemDBusName = dbusName
+    } = do
+    client <- connectSession
+    let getTooltip :: IO (String, [(Int32, Int32, BS.ByteString)], String, String)
+        getTooltip = return ("", [], "Title", "Text")
+    let clientInterface =
+          Interface
+            { interfaceName = "org.kde.StatusNotifierItem",
+              interfaceMethods = [],
+              interfaceProperties =
+                [ readOnlyProperty "IconName" $ return name,
+                  readOnlyProperty "OverlayIconName" $ return overlayName,
+                  readOnlyProperty "ToolTip" getTooltip
+                ],
+              interfaceSignals = []
+            }
+    export client (fromString "/StatusNotifierItem") clientInterface
+    requestName client (busName_ dbusName) []
+    W.registerStatusNotifierItem client dbusName

--- a/packages/status-notifier-item/src/StatusNotifier/TH.hs
+++ b/packages/status-notifier-item/src/StatusNotifier/TH.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+
 module StatusNotifier.TH where
 
 import DBus.Client
@@ -6,5 +7,5 @@ import DBus.Generation
 
 -- XXX: Move this to haskell-dbus
 generateClient defaultGenerationParams $
-               buildIntrospectionInterface $
-               buildIntrospectableInterface undefined
+  buildIntrospectionInterface $
+    buildIntrospectableInterface undefined

--- a/packages/status-notifier-item/src/StatusNotifier/Util.hs
+++ b/packages/status-notifier-item/src/StatusNotifier/Util.hs
@@ -1,36 +1,38 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module StatusNotifier.Util where
 
-import           Control.Arrow
-import           Control.Lens
-import           DBus.Client
+import Control.Arrow
+import Control.Lens
+import DBus.Client
 import qualified DBus.Generation as G
 import qualified DBus.Internal.Message as M
 import qualified DBus.Internal.Types as T
 import qualified DBus.Introspection as I
-import           Data.Bits
+import Data.Bits
 import qualified Data.ByteString as BS
-import           Data.Maybe
-import qualified Data.Vector.Storable as VS
-import           Data.Vector.Storable.ByteString
-import           Data.Word
-import           Language.Haskell.TH
-import           StatusNotifier.TH
+import Data.Maybe
+import Data.Text (pack)
 import qualified Data.Text.IO as TIO
-import           Data.Text (pack)
-import           System.ByteOrder (fromBigEndian)
-import           System.Log.Logger
+import qualified Data.Vector.Storable as VS
+import Data.Vector.Storable.ByteString
+import Data.Word
+import Language.Haskell.TH
+import StatusNotifier.TH
+import System.ByteOrder (fromBigEndian)
+import System.Log.Logger
 
 splitServiceName :: String -> (String, Maybe String)
 splitServiceName name =
-  case break (=='/') name of
+  case break (== '/') name of
     (bus, "") -> (bus, Nothing)
     (bus, path) | not (null bus) -> (bus, Just path)
     _ -> (name, Nothing)
 
 getIntrospectionObjectFromFile :: FilePath -> T.ObjectPath -> Q I.Object
-getIntrospectionObjectFromFile filepath nodePath = runIO $
-  head . maybeToList . I.parseXML nodePath <$> TIO.readFile filepath
+getIntrospectionObjectFromFile filepath nodePath =
+  runIO $
+    head . maybeToList . I.parseXML nodePath <$> TIO.readFile filepath
 
 generateClientFromFile :: G.GenerationParams -> Bool -> FilePath -> Q [Dec]
 generateClientFromFile params useObjectPath filepath = do
@@ -39,22 +41,24 @@ generateClientFromFile params useObjectPath filepath = do
       actualObjectPath = I.objectPath object
       realParams =
         if useObjectPath
-        then params { G.genObjectPath = Just actualObjectPath }
-        else params
-  (++) <$> G.generateClient realParams interface <*>
-           G.generateSignalsFromInterface realParams interface
+          then params {G.genObjectPath = Just actualObjectPath}
+          else params
+  (++)
+    <$> G.generateClient realParams interface
+    <*> G.generateSignalsFromInterface realParams interface
 
-ifM :: Monad m => m Bool -> m a -> m a -> m a
+ifM :: (Monad m) => m Bool -> m a -> m a -> m a
 ifM cond whenTrue whenFalse =
   cond >>= (\bool -> if bool then whenTrue else whenFalse)
 
 makeLensesWithLSuffix :: Name -> DecsQ
 makeLensesWithLSuffix =
   makeLensesWith $
-  lensRules & lensField .~ \_ _ name ->
-    [TopName (mkName $ nameBase name ++ "L")]
+    lensRules
+      & lensField .~ \_ _ name ->
+        [TopName (mkName $ nameBase name ++ "L")]
 
-whenJust :: Monad m => Maybe a -> (a -> m ()) -> m ()
+whenJust :: (Monad m) => Maybe a -> (a -> m ()) -> m ()
 whenJust = flip $ maybe $ return ()
 
 convertARGBToABGR :: Word32 -> Word32
@@ -76,11 +80,11 @@ makeErrorReply :: ErrorName -> String -> Reply
 makeErrorReply e message = ReplyError e [T.toVariant message]
 
 logErrorWithDefault ::
-  Show a => (Priority -> String -> IO ()) -> b -> String -> Either a b -> IO b
+  (Show a) => (Priority -> String -> IO ()) -> b -> String -> Either a b -> IO b
 logErrorWithDefault logger def message =
   fmap (fromMaybe def) . logEitherError logger message
 
-logEitherError :: Show a => (Priority -> String -> IO ()) -> String -> Either a b -> IO (Maybe b)
+logEitherError :: (Show a) => (Priority -> String -> IO ()) -> String -> Either a b -> IO (Maybe b)
 logEitherError logger message =
   either (\err -> logger ERROR (message ++ show err) >> return Nothing) (return . Just)
 
@@ -89,10 +93,10 @@ exemptUnknownMethod ::
 exemptUnknownMethod def eitherV =
   case eitherV of
     Right _ -> eitherV
-    Left M.MethodError { M.methodErrorName = errorName } ->
+    Left M.MethodError {M.methodErrorName = errorName} ->
       if errorName == errorUnknownMethod
-      then Right def
-      else eitherV
+        then Right def
+        else eitherV
 
 exemptAll ::
   b -> Either M.MethodError b -> Either M.MethodError b
@@ -102,34 +106,36 @@ exemptAll def eitherV =
     Left _ -> Right def
 
 infixl 4 <..>
-(<..>) :: Functor f => (a -> b) -> f (f a) -> f (f b)
+
+(<..>) :: (Functor f) => (a -> b) -> f (f a) -> f (f b)
 (<..>) = fmap . fmap
 
 infixl 4 <<$>>
-(<<$>>) :: (a -> IO b) -> Maybe a -> IO (Maybe b)
-fn <<$>> m = sequenceA $ fn <$> m
 
-forkM :: Monad m => (i -> m a) -> (i -> m b) -> i -> m (a, b)
+(<<$>>) :: (a -> IO b) -> Maybe a -> IO (Maybe b)
+fn <<$>> m = traverse fn m
+
+forkM :: (Monad m) => (i -> m a) -> (i -> m b) -> i -> m (a, b)
 forkM a b i =
   do
     r1 <- a i
     r2 <- b i
     return (r1, r2)
 
-tee :: Monad m => (i -> m a) -> (i -> m b) -> i -> m a
+tee :: (Monad m) => (i -> m a) -> (i -> m b) -> i -> m a
 tee = (fmap . fmap . fmap) (fmap fst) forkM
 
-(>>=/) :: Monad m => m a -> (a -> m b) -> m a
+(>>=/) :: (Monad m) => m a -> (a -> m b) -> m a
 (>>=/) a = (a >>=) . tee return
 
-getInterfaceAt
-  :: Client
-  -> T.BusName
-  -> T.ObjectPath
-  -> IO (Either M.MethodError (Maybe I.Object))
+getInterfaceAt ::
+  Client ->
+  T.BusName ->
+  T.ObjectPath ->
+  IO (Either M.MethodError (Maybe I.Object))
 getInterfaceAt client bus path =
   right (I.parseXML "/" . pack) <$> introspect client bus path
 
-findM :: Monad m => (a -> m Bool) -> [a] -> m (Maybe a)
-findM p [] = return Nothing
-findM p (x:xs) = ifM (p x) (return $ Just x) (findM p xs)
+findM :: (Monad m) => (a -> m Bool) -> [a] -> m (Maybe a)
+findM p =
+  foldr (\x -> ifM (p x) (return $ Just x)) (return Nothing)

--- a/packages/status-notifier-item/src/StatusNotifier/Watcher/Client.hs
+++ b/packages/status-notifier-item/src/StatusNotifier/Watcher/Client.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE TemplateHaskell #-}
+
 module StatusNotifier.Watcher.Client where
 
 import DBus.Generation
 import Language.Haskell.TH
-
 import StatusNotifier.Watcher.Constants
 import StatusNotifier.Watcher.Service
 
 generateClient watcherClientGenerationParams watcherInterface
 
 printWatcherClient =
-  runQ (generateClient watcherClientGenerationParams watcherInterface) >>=
-       putStrLn . pprint
+  runQ (generateClient watcherClientGenerationParams watcherInterface)
+    >>= putStrLn . pprint

--- a/packages/status-notifier-item/src/StatusNotifier/Watcher/Constants.hs
+++ b/packages/status-notifier-item/src/StatusNotifier/Watcher/Constants.hs
@@ -1,16 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module StatusNotifier.Watcher.Constants where
 
-import           DBus.Client
-import           DBus.Generation
-import           DBus.Internal.Types
+import DBus.Client
+import DBus.Generation
+import DBus.Internal.Types
 import qualified DBus.Introspection as I
-import           Data.Coerce
-import           Data.String
-import           StatusNotifier.Util
-import           System.IO.Unsafe
-import           System.Log.Logger
-import           Text.Printf
+import Data.Coerce
+import Data.String
+import StatusNotifier.Util
+import System.IO.Unsafe
+import System.Log.Logger
+import Text.Printf
 
 statusNotifierWatcherString :: String
 statusNotifierWatcherString = "StatusNotifierWatcher"
@@ -20,50 +21,61 @@ getWatcherInterfaceName interfaceNamespace =
   fromString $ printf "%s.%s" interfaceNamespace statusNotifierWatcherString
 
 data ItemEntry = ItemEntry
-  { serviceName :: BusName
-  , servicePath :: ObjectPath
-  } deriving (Show, Eq)
+  { serviceName :: BusName,
+    servicePath :: ObjectPath
+  }
+  deriving (Show, Eq)
 
 data WatcherParams = WatcherParams
-  { watcherNamespace :: String
-  , watcherPath :: String
-  , watcherStop :: IO ()
-  , watcherDBusClient :: Maybe Client
-  , watcherStateCachePath :: Maybe FilePath
+  { watcherNamespace :: String,
+    watcherPath :: String,
+    watcherStop :: IO (),
+    watcherDBusClient :: Maybe Client,
+    watcherStateCachePath :: Maybe FilePath
   }
 
 defaultWatcherParams :: WatcherParams
 defaultWatcherParams =
   WatcherParams
-  { watcherNamespace = "org.kde"
-  , watcherStop = return ()
-  , watcherPath = "/StatusNotifierWatcher"
-  , watcherDBusClient = Nothing
-  , watcherStateCachePath = Nothing
-  }
+    { watcherNamespace = "org.kde",
+      watcherStop = return (),
+      watcherPath = "/StatusNotifierWatcher",
+      watcherDBusClient = Nothing,
+      watcherStateCachePath = Nothing
+    }
 
 defaultWatcherInterfaceName =
   getWatcherInterfaceName $ watcherNamespace defaultWatcherParams
 
-serviceArg = I.SignalArg { I.signalArgName = "service"
-                         , I.signalArgType = TypeString
-                         }
+serviceArg =
+  I.SignalArg
+    { I.signalArgName = "service",
+      I.signalArgType = TypeString
+    }
 
-watcherSignals = [ I.Signal { I.signalName = "StatusNotifierItemRegistered"
-                            , I.signalArgs = [serviceArg]
-                            }
-                 , I.Signal { I.signalName = "StatusNotifierItemUnregistered"
-                            , I.signalArgs = [serviceArg]
-                            }
-                 , I.Signal { I.signalName = "StatusNotifierHostRegistered"
-                            , I.signalArgs = []
-                            }
-                 ]
+watcherSignals =
+  [ I.Signal
+      { I.signalName = "StatusNotifierItemRegistered",
+        I.signalArgs = [serviceArg]
+      },
+    I.Signal
+      { I.signalName = "StatusNotifierItemUnregistered",
+        I.signalArgs = [serviceArg]
+      },
+    I.Signal
+      { I.signalName = "StatusNotifierHostRegistered",
+        I.signalArgs = []
+      }
+  ]
 
 watcherClientGenerationParams =
   defaultGenerationParams
-  { genBusName = Just $ fromString $ coerce $ getWatcherInterfaceName
-                 (watcherNamespace defaultWatcherParams)
-  , genObjectPath = Just $ fromString $ watcherPath defaultWatcherParams
-  , genTakeSignalErrorHandler = True
-  }
+    { genBusName =
+        Just $
+          fromString $
+            coerce $
+              getWatcherInterfaceName
+                (watcherNamespace defaultWatcherParams),
+      genObjectPath = Just $ fromString $ watcherPath defaultWatcherParams,
+      genTakeSignalErrorHandler = True
+    }

--- a/packages/status-notifier-item/src/StatusNotifier/Watcher/Service.hs
+++ b/packages/status-notifier-item/src/StatusNotifier/Watcher/Service.hs
@@ -1,387 +1,435 @@
-{-# LANGUAGE OverloadedStrings, FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module StatusNotifier.Watcher.Service where
 
-import           Control.Arrow
-import           Control.Concurrent.MVar
-import           Control.Monad
-import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Except
-import           DBus
-import           DBus.Client
-import           DBus.Generation
-import           DBus.Internal.Message as M
-import           DBus.Internal.Types
+import Control.Arrow
+import Control.Concurrent.MVar
+import Control.Monad
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Except
+import DBus
+import DBus.Client
+import DBus.Generation
+import DBus.Internal.Message as M
+import DBus.Internal.Types
 import qualified DBus.Internal.Types as T
 import qualified DBus.Introspection as I
 import qualified DBus.TH as DBusTH
-import           Data.Coerce
-import           Data.Int
-import           Data.List
-import           Data.Maybe
-import           Data.Monoid
-import           Data.String
+import Data.Coerce
+import Data.Int
+import Data.List
+import Data.Maybe
+import Data.Monoid
+import Data.String
 import qualified StatusNotifier.Item.Client as Item
-import           StatusNotifier.Util
-import           StatusNotifier.Watcher.Constants
-import           StatusNotifier.Watcher.StateCache
-import           StatusNotifier.Watcher.Signals
-import           System.IO.Unsafe
-import           System.Log.Logger
-import           Text.Printf
+import StatusNotifier.Util
+import StatusNotifier.Watcher.Constants
+import StatusNotifier.Watcher.Signals
+import StatusNotifier.Watcher.StateCache
+import System.IO.Unsafe
+import System.Log.Logger
+import Text.Printf
 
-buildWatcher WatcherParams
-               { watcherNamespace = interfaceNamespace
-               , watcherStop = stopWatcher
-               , watcherPath = path
-               , watcherDBusClient = mclient
-               , watcherStateCachePath = maybeCachePath
-               } = do
-  let watcherInterfaceName = getWatcherInterfaceName interfaceNamespace
-      logNamespace = "StatusNotifier.Watcher.Service"
-      logInfo = logM logNamespace INFO
-      logDebug = logM logNamespace DEBUG
-      logError = logM logNamespace ERROR
-      -- Default level is now INFO (watcher/Main.hs). Keep generic per-request
-      -- logging at DEBUG to avoid spamming INFO for frequent property reads.
-      mkLogCb cb msg = lift (logDebug (show msg)) >> cb msg
-      mkLogMethod method = method { methodHandler = mkLogCb $ methodHandler method }
-      mkLogProperty name fn =
-        readOnlyProperty name $ logDebug (coerce name ++ " Called") >> fn
+buildWatcher
+  WatcherParams
+    { watcherNamespace = interfaceNamespace,
+      watcherStop = stopWatcher,
+      watcherPath = path,
+      watcherDBusClient = mclient,
+      watcherStateCachePath = maybeCachePath
+    } = do
+    let watcherInterfaceName = getWatcherInterfaceName interfaceNamespace
+        logNamespace = "StatusNotifier.Watcher.Service"
+        logInfo = logM logNamespace INFO
+        logDebug = logM logNamespace DEBUG
+        logError = logM logNamespace ERROR
+        -- Default level is now INFO (watcher/Main.hs). Keep generic per-request
+        -- logging at DEBUG to avoid spamming INFO for frequent property reads.
+        mkLogCb cb msg = lift (logDebug (show msg)) >> cb msg
+        mkLogMethod method = method {methodHandler = mkLogCb $ methodHandler method}
+        mkLogProperty name fn =
+          readOnlyProperty name $ logDebug (coerce name ++ " Called") >> fn
 
-  client <- maybe connectSession return mclient
-  cachePath <- maybe (defaultWatcherStateCachePath interfaceNamespace path)
-                     pure
-                     maybeCachePath
+    client <- maybe connectSession return mclient
+    cachePath <-
+      maybe
+        (defaultWatcherStateCachePath interfaceNamespace path)
+        pure
+        maybeCachePath
 
-  notifierItems <- newMVar []
-  notifierHosts <- newMVar []
+    notifierItems <- newMVar []
+    notifierHosts <- newMVar []
 
-  let itemIsRegistered item items =
-        isJust $ find (== item) items
+    let itemIsRegistered item items =
+          isJust $ find (== item) items
 
-      persistWatcherState = do
-        currentItems <- readMVar notifierItems
-        currentHosts <- readMVar notifierHosts
-        let toPersisted entry =
-              PersistedItemEntry
-                { persistedServiceName = coerce (serviceName entry)
-                , persistedServicePath = coerce (servicePath entry)
-                }
-            persistedState =
-              PersistedWatcherState
-                { persistedItems = map toPersisted currentItems
-                , persistedHosts = map toPersisted currentHosts
-                }
-        writePersistedWatcherState cachePath persistedState >>=
-          either
-            (\err ->
-               logError $
-                 printf "Failed to persist watcher state to %s: %s" cachePath err
-            )
-            (const $ return ())
+        persistWatcherState = do
+          currentItems <- readMVar notifierItems
+          currentHosts <- readMVar notifierHosts
+          let toPersisted entry =
+                PersistedItemEntry
+                  { persistedServiceName = coerce (serviceName entry),
+                    persistedServicePath = coerce (servicePath entry)
+                  }
+              persistedState =
+                PersistedWatcherState
+                  { persistedItems = map toPersisted currentItems,
+                    persistedHosts = map toPersisted currentHosts
+                  }
+          writePersistedWatcherState cachePath persistedState
+            >>= either
+              (logError . printf "Failed to persist watcher state to %s: %s" cachePath)
+              (const $ return ())
 
-      renderServiceName :: ItemEntry -> String
-      renderServiceName ItemEntry { serviceName = busName
-                                  , servicePath = path
-                                  } =
-        let bus = (coerce busName :: String)
-            objPath = (coerce path :: String)
-            defaultPath = (coerce Item.defaultPath :: String)
-        in if objPath == defaultPath
-           then bus
-           else bus ++ objPath
+        renderServiceName :: ItemEntry -> String
+        renderServiceName
+          ItemEntry
+            { serviceName = busName,
+              servicePath = path
+            } =
+            let bus = (coerce busName :: String)
+                objPath = (coerce path :: String)
+                defaultPath = (coerce Item.defaultPath :: String)
+             in if objPath == defaultPath
+                  then bus
+                  else bus ++ objPath
 
-      resolveOwner bus
-        | ":" `isPrefixOf` (coerce bus :: String) = return (Just bus)
-        | otherwise = do
-            result <- DBusTH.getNameOwner client (coerce bus)
-            return $ busName_ <$> either (const Nothing) Just result
+        resolveOwner bus
+          | ":" `isPrefixOf` (coerce bus :: String) = return (Just bus)
+          | otherwise = do
+              result <- DBusTH.getNameOwner client (coerce bus)
+              return $ busName_ <$> either (const Nothing) Just result
 
-      insertItemNoSignal owner item currentItems = do
-        ownerPathMatches <-
-          case owner of
-            Nothing -> return []
-            Just itemOwner ->
-              filterM
-                (\existingItem ->
-                   if servicePath existingItem == servicePath item
-                     then do
-                       existingOwner <- resolveOwner (serviceName existingItem)
-                       return $ existingOwner == Just itemOwner
-                     else return False
-                )
-                currentItems
-        if itemIsRegistered item currentItems
-          then return (currentItems, False)
-          else
-            if null ownerPathMatches
-              then return (item : currentItems, True)
-              else
-                let removeMatches =
-                      foldl' (flip delete) currentItems ownerPathMatches
-                in return (item : removeMatches, True)
-
-      insertHostNoSignal host currentHosts =
-        if itemIsRegistered host currentHosts
-          then (currentHosts, False)
-          else (host : currentHosts, True)
-
-      parsePersistedItemEntry persistedEntry = do
-        parsedBusName <- T.parseBusName (persistedServiceName persistedEntry)
-        parsedPath <- T.parseObjectPath (persistedServicePath persistedEntry)
-        return ItemEntry
-          { serviceName = parsedBusName
-          , servicePath = parsedPath
-          }
-
-      statusNotifierItemInterfaceName = fromString "org.kde.StatusNotifierItem"
-      hasStatusNotifierItemInterface objectInfo =
-        any ((== statusNotifierItemInterfaceName) . I.interfaceName) $
-        I.objectInterfaces objectInfo
-
-      validatePersistedItem persistedEntry =
-        case parsePersistedItemEntry persistedEntry of
-          Nothing -> do
-            logError $ printf "Dropping unparsable cached item entry: %s" $
-              show persistedEntry
-            return Nothing
-          Just item -> do
-            owner <- resolveOwner (serviceName item)
+        insertItemNoSignal owner item currentItems = do
+          ownerPathMatches <-
             case owner of
-              Nothing -> do
-                logInfo $
-                  printf "Dropping cached item %s because the bus name is no longer owned."
-                    (renderServiceName item)
-                return Nothing
-              Just validOwner -> do
-                objectResult <-
-                  getInterfaceAt client (serviceName item) (servicePath item)
-                case objectResult of
-                  Right (Just objectInfo)
-                    | hasStatusNotifierItemInterface objectInfo ->
-                        return $ Just (item, validOwner)
-                  _ -> do
-                    logInfo $
-                      printf "Dropping cached item %s because it no longer exposes org.kde.StatusNotifierItem."
-                        (renderServiceName item)
-                    return Nothing
+              Nothing -> return []
+              Just itemOwner ->
+                filterM
+                  ( \existingItem ->
+                      if servicePath existingItem == servicePath item
+                        then do
+                          existingOwner <- resolveOwner (serviceName existingItem)
+                          return $ existingOwner == Just itemOwner
+                        else return False
+                  )
+                  currentItems
+          if itemIsRegistered item currentItems
+            then return (currentItems, False)
+            else
+              if null ownerPathMatches
+                then return (item : currentItems, True)
+                else
+                  let removeMatches =
+                        foldl' (flip delete) currentItems ownerPathMatches
+                   in return (item : removeMatches, True)
 
-      validatePersistedHost persistedEntry =
-        case parsePersistedItemEntry persistedEntry of
-          Nothing -> do
-            logError $ printf "Dropping unparsable cached host entry: %s" $
-              show persistedEntry
-            return Nothing
-          Just host -> do
-            owner <- resolveOwner (serviceName host)
-            if isNothing owner
-              then do
-                logInfo $
-                  printf "Dropping cached host %s because the bus name is no longer owned."
-                    (coerce (serviceName host) :: String)
-                return Nothing
-              else return $ Just host
+        insertHostNoSignal host currentHosts =
+          if itemIsRegistered host currentHosts
+            then (currentHosts, False)
+            else (host : currentHosts, True)
 
-      restoreWatcherStateFromCache = do
-        stateResult <- readPersistedWatcherState cachePath
-        case stateResult of
-          Left err -> do
-            logError $
-              printf "Failed to read watcher cache state from %s: %s" cachePath err
-            return ([], [])
-          Right Nothing -> return ([], [])
-          Right (Just persistedState) -> do
-            validItems <- catMaybes <$> mapM validatePersistedItem (persistedItems persistedState)
-            validHosts <- catMaybes <$> mapM validatePersistedHost (persistedHosts persistedState)
+        parsePersistedItemEntry persistedEntry = do
+          parsedBusName <- T.parseBusName (persistedServiceName persistedEntry)
+          parsedPath <- T.parseObjectPath (persistedServicePath persistedEntry)
+          return
+            ItemEntry
+              { serviceName = parsedBusName,
+                servicePath = parsedPath
+              }
 
-            restoredItems <-
-              modifyMVar notifierItems $ \currentItems -> do
-                (newItems, insertedItemsRev) <-
-                  foldM
-                    (\(accItems, accInserted) (item, itemOwner) -> do
-                       (nextItems, inserted) <- insertItemNoSignal (Just itemOwner) item accItems
-                       if inserted
-                         then return (nextItems, item : accInserted)
-                         else return (nextItems, accInserted)
-                    )
-                    (currentItems, [])
-                    validItems
-                return (newItems, reverse insertedItemsRev)
+        statusNotifierItemInterfaceName = fromString "org.kde.StatusNotifierItem"
+        hasStatusNotifierItemInterface objectInfo =
+          any ((== statusNotifierItemInterfaceName) . I.interfaceName) $
+            I.objectInterfaces objectInfo
 
-            restoredHosts <-
-              modifyMVar notifierHosts $ \currentHosts -> do
-                let insertHost (accHosts, accInserted) host =
-                      let (nextHosts, inserted) = insertHostNoSignal host accHosts
-                      in if inserted
-                           then (nextHosts, host : accInserted)
-                           else (nextHosts, accInserted)
-                    (newHosts, insertedHostsRev) = foldl' insertHost (currentHosts, []) validHosts
-                return (newHosts, reverse insertedHostsRev)
+        validatePersistedItem persistedEntry =
+          case parsePersistedItemEntry persistedEntry of
+            Nothing -> do
+              logError $
+                printf "Dropping unparsable cached item entry: %s" $
+                  show persistedEntry
+              return Nothing
+            Just item -> do
+              owner <- resolveOwner (serviceName item)
+              case owner of
+                Nothing -> do
+                  logInfo $
+                    printf
+                      "Dropping cached item %s because the bus name is no longer owned."
+                      (renderServiceName item)
+                  return Nothing
+                Just validOwner -> do
+                  objectResult <-
+                    getInterfaceAt client (serviceName item) (servicePath item)
+                  case objectResult of
+                    Right (Just objectInfo)
+                      | hasStatusNotifierItemInterface objectInfo ->
+                          return $ Just (item, validOwner)
+                    _ -> do
+                      logInfo $
+                        printf
+                          "Dropping cached item %s because it no longer exposes org.kde.StatusNotifierItem."
+                          (renderServiceName item)
+                      return Nothing
 
-            persistWatcherState
-            return (restoredItems, restoredHosts)
+        validatePersistedHost persistedEntry =
+          case parsePersistedItemEntry persistedEntry of
+            Nothing -> do
+              logError $
+                printf "Dropping unparsable cached host entry: %s" $
+                  show persistedEntry
+              return Nothing
+            Just host -> do
+              owner <- resolveOwner (serviceName host)
+              if isNothing owner
+                then do
+                  logInfo $
+                    printf
+                      "Dropping cached host %s because the bus name is no longer owned."
+                      (coerce (serviceName host) :: String)
+                  return Nothing
+                else return $ Just host
 
-      registerStatusNotifierItem MethodCall
-                                   { methodCallSender = sender }
-                                 name = runExceptT $ do
-        let parsedBusName = T.parseBusName name
-            parseServiceError = makeErrorReply errorInvalidParameters $
-              printf "the provided service %s could not be parsed \
-                     \as a bus name or an object path." name
-            senderMissingError = makeErrorReply errorInvalidParameters $
-              "Unable to identify sender for registration."
-            path = fromMaybe Item.defaultPath $ T.parseObjectPath name
-            remapErrorName =
-              left $ (`makeErrorReply` "Failed to verify ownership.") .
-                   M.methodErrorName
-        when (isNothing parsedBusName && isNothing (T.parseObjectPath name)) $
-          throwE parseServiceError
-        senderName <- ExceptT $ return $ maybeToEither senderMissingError sender
-        busName <-
-          case parsedBusName of
-            Just providedBusName
-              -- Unique bus names (starting with ':') are assigned by the D-Bus
-              -- daemon and cannot be spoofed. Some applications (e.g. KDE's
-              -- KStatusNotifierItem) register their SNI on a separate D-Bus
-              -- connection, so the sender's unique name differs from the
-              -- registered item's unique name even though they belong to the
-              -- same process. Skip the ownership check for unique names.
-              | ":" `isPrefixOf` (coerce providedBusName :: String) ->
-                  return providedBusName
-              | otherwise -> do
-                  owner <- ExceptT $ remapErrorName <$>
-                           DBusTH.getNameOwner client (coerce providedBusName)
-                  unless (owner == coerce senderName) $
-                    throwE $ makeErrorReply errorInvalidParameters $
-                      printf "Sender %s does not own service %s."
-                        (coerce senderName :: String)
-                        name
-                  return providedBusName
-            Nothing -> return senderName
-        let item = ItemEntry { serviceName = busName
-                             , servicePath = path
-                             }
-        changed <- lift $ modifyMVar notifierItems $ \currentItems -> do
-          (newItems, inserted) <- insertItemNoSignal (Just senderName) item currentItems
-          return (newItems, inserted)
-        lift $
-          when changed $ do
-            logInfo $ printf "Registered item %s." (renderServiceName item)
-            emitStatusNotifierItemRegistered client $ renderServiceName item
-            persistWatcherState
+        restoreWatcherStateFromCache = do
+          stateResult <- readPersistedWatcherState cachePath
+          case stateResult of
+            Left err -> do
+              logError $
+                printf "Failed to read watcher cache state from %s: %s" cachePath err
+              return ([], [])
+            Right Nothing -> return ([], [])
+            Right (Just persistedState) -> do
+              validItems <- catMaybes <$> mapM validatePersistedItem (persistedItems persistedState)
+              validHosts <- catMaybes <$> mapM validatePersistedHost (persistedHosts persistedState)
 
-      registerStatusNotifierHost name =
-        let item = ItemEntry { serviceName = busName_ name
-                             , servicePath = "/StatusNotifierHost"
-                             } in
-        do
-          changed <- modifyMVar notifierHosts $ \currentHosts ->
-            let (newHosts, inserted) = insertHostNoSignal item currentHosts
-            in return (newHosts, inserted)
-          when changed $ do
-            logInfo $ printf "Registered host %s." name
-            emitStatusNotifierHostRegistered client
-            persistWatcherState
+              restoredItems <-
+                modifyMVar notifierItems $ \currentItems -> do
+                  (newItems, insertedItemsRev) <-
+                    foldM
+                      ( \(accItems, accInserted) (item, itemOwner) -> do
+                          (nextItems, inserted) <- insertItemNoSignal (Just itemOwner) item accItems
+                          if inserted
+                            then return (nextItems, item : accInserted)
+                            else return (nextItems, accInserted)
+                      )
+                      (currentItems, [])
+                      validItems
+                  return (newItems, reverse insertedItemsRev)
 
-      registeredStatusNotifierItems :: IO [String]
-      registeredStatusNotifierItems =
-        map renderServiceName <$> readMVar notifierItems
+              restoredHosts <-
+                modifyMVar notifierHosts $ \currentHosts -> do
+                  let insertHost (accHosts, accInserted) host =
+                        let (nextHosts, inserted) = insertHostNoSignal host accHosts
+                         in if inserted
+                              then (nextHosts, host : accInserted)
+                              else (nextHosts, accInserted)
+                      (newHosts, insertedHostsRev) = foldl' insertHost (currentHosts, []) validHosts
+                  return (newHosts, reverse insertedHostsRev)
 
-      registeredSNIEntries :: IO [(String, String)]
-      registeredSNIEntries =
-        map getTuple <$> readMVar notifierItems
-          where getTuple (ItemEntry bname path) = (coerce bname, coerce path)
+              persistWatcherState
+              return (restoredItems, restoredHosts)
 
-      objectPathForItem :: String -> IO (Either Reply String)
-      objectPathForItem name =
-        case splitServiceName name of
-          (_, Just path) -> return $ Right path
-          (bus, Nothing) ->
-            maybeToEither notFoundError . fmap (coerce . servicePath) .
-            find ((== busName_ bus) . serviceName) <$>
-            readMVar notifierItems
-        where notFoundError =
-                makeErrorReply errorInvalidParameters $
+        registerStatusNotifierItem
+          MethodCall
+            { methodCallSender = sender
+            }
+          name = runExceptT $ do
+            let parsedBusName = T.parseBusName name
+                parseServiceError =
+                  makeErrorReply errorInvalidParameters $
+                    printf
+                      "the provided service %s could not be parsed \
+                      \as a bus name or an object path."
+                      name
+                senderMissingError =
+                  makeErrorReply
+                    errorInvalidParameters
+                    "Unable to identify sender for registration."
+                path = fromMaybe Item.defaultPath $ T.parseObjectPath name
+                remapErrorName =
+                  left $
+                    (`makeErrorReply` "Failed to verify ownership.")
+                      . M.methodErrorName
+            when (isNothing parsedBusName && isNothing (T.parseObjectPath name)) $
+              throwE parseServiceError
+            senderName <- ExceptT $ return $ maybeToEither senderMissingError sender
+            busName <-
+              case parsedBusName of
+                Just providedBusName
+                  -- Unique bus names (starting with ':') are assigned by the D-Bus
+                  -- daemon and cannot be spoofed. Some applications (e.g. KDE's
+                  -- KStatusNotifierItem) register their SNI on a separate D-Bus
+                  -- connection, so the sender's unique name differs from the
+                  -- registered item's unique name even though they belong to the
+                  -- same process. Skip the ownership check for unique names.
+                  | ":" `isPrefixOf` (coerce providedBusName :: String) ->
+                      return providedBusName
+                  | otherwise -> do
+                      owner <-
+                        ExceptT $
+                          remapErrorName
+                            <$> DBusTH.getNameOwner client (coerce providedBusName)
+                      unless (owner == coerce senderName) $
+                        throwE $
+                          makeErrorReply errorInvalidParameters $
+                            printf
+                              "Sender %s does not own service %s."
+                              (coerce senderName :: String)
+                              name
+                      return providedBusName
+                Nothing -> return senderName
+            let item =
+                  ItemEntry
+                    { serviceName = busName,
+                      servicePath = path
+                    }
+            changed <- lift $ modifyMVar notifierItems $ \currentItems -> do
+              (newItems, inserted) <- insertItemNoSignal (Just senderName) item currentItems
+              return (newItems, inserted)
+            lift $
+              when changed $ do
+                logInfo $ printf "Registered item %s." (renderServiceName item)
+                emitStatusNotifierItemRegistered client $ renderServiceName item
+                persistWatcherState
+
+        registerStatusNotifierHost name =
+          let item =
+                ItemEntry
+                  { serviceName = busName_ name,
+                    servicePath = "/StatusNotifierHost"
+                  }
+           in do
+                changed <- modifyMVar notifierHosts $ \currentHosts ->
+                  let (newHosts, inserted) = insertHostNoSignal item currentHosts
+                   in return (newHosts, inserted)
+                when changed $ do
+                  logInfo $ printf "Registered host %s." name
+                  emitStatusNotifierHostRegistered client
+                  persistWatcherState
+
+        registeredStatusNotifierItems :: IO [String]
+        registeredStatusNotifierItems =
+          map renderServiceName <$> readMVar notifierItems
+
+        registeredSNIEntries :: IO [(String, String)]
+        registeredSNIEntries =
+          map getTuple <$> readMVar notifierItems
+          where
+            getTuple (ItemEntry bname path) = (coerce bname, coerce path)
+
+        objectPathForItem :: String -> IO (Either Reply String)
+        objectPathForItem name =
+          case splitServiceName name of
+            (_, Just path) -> return $ Right path
+            (bus, Nothing) ->
+              maybeToEither notFoundError
+                . fmap (coerce . servicePath)
+                . find ((== busName_ bus) . serviceName)
+                <$> readMVar notifierItems
+          where
+            notFoundError =
+              makeErrorReply errorInvalidParameters $
                 printf "Service %s is not registered." name
 
-      isStatusNotifierHostRegistered = not . null <$> readMVar notifierHosts
+        isStatusNotifierHostRegistered = not . null <$> readMVar notifierHosts
 
-      protocolVersion = return 0 :: IO Int32
+        protocolVersion = return 0 :: IO Int32
 
-      filterDeadService :: String -> MVar [ItemEntry] -> IO [ItemEntry]
-      filterDeadService deadService mvar = modifyMVar mvar $
-        return . partition ((/= busName_ deadService) . serviceName)
+        filterDeadService :: String -> MVar [ItemEntry] -> IO [ItemEntry]
+        filterDeadService deadService mvar =
+          modifyMVar mvar $
+            return . partition ((/= busName_ deadService) . serviceName)
 
-      handleNameOwnerChanged _ name oldOwner newOwner =
-        when (newOwner == "") $ do
-          removedItems <- filterDeadService name notifierItems
-          unless (null removedItems) $ do
-            logInfo $ printf "Unregistering item %s because it disappeared." name
-            forM_ removedItems $ \item ->
-              emitStatusNotifierItemUnregistered client $ renderServiceName item
-          removedHosts <- filterDeadService name notifierHosts
-          unless (null removedHosts) $
-            logInfo $ printf "Unregistering host %s because it disappeared." name
-          when (not (null removedItems) || not (null removedHosts)) $
-            persistWatcherState
-          return ()
-
-      watcherMethods = map mkLogMethod
-        [ autoMethodWithMsg "RegisterStatusNotifierItem"
-          registerStatusNotifierItem
-        , autoMethod "RegisterStatusNotifierHost"
-          registerStatusNotifierHost
-        , autoMethod "StopWatcher"
-          stopWatcher
-        , autoMethod "GetObjectPathForItemName"
-          objectPathForItem
-        ]
-
-      watcherProperties =
-        [ mkLogProperty "RegisteredStatusNotifierItems"
-          registeredStatusNotifierItems
-        , mkLogProperty "RegisteredSNIEntries"
-          registeredSNIEntries
-        , mkLogProperty "IsStatusNotifierHostRegistered"
-          isStatusNotifierHostRegistered
-        , mkLogProperty "ProtocolVersion"
-          protocolVersion
-        ]
-
-      watcherInterface =
-        Interface
-        { interfaceName = watcherInterfaceName
-        , interfaceMethods = watcherMethods
-        , interfaceProperties = watcherProperties
-        , interfaceSignals = watcherSignals
-        }
-
-      startWatcher = do
-        nameRequestResult <- requestName client (coerce watcherInterfaceName) []
-        case nameRequestResult of
-          NamePrimaryOwner ->
-            do
-              _ <- DBusTH.registerForNameOwnerChanged client
-                   matchAny handleNameOwnerChanged
-              (restoredItems, restoredHosts) <- restoreWatcherStateFromCache
-              export client (fromString path) watcherInterface
+        handleNameOwnerChanged _ name oldOwner newOwner =
+          when (newOwner == "") $ do
+            removedItems <- filterDeadService name notifierItems
+            unless (null removedItems) $ do
+              logInfo $ printf "Unregistering item %s because it disappeared." name
+              forM_ removedItems $ \item ->
+                emitStatusNotifierItemUnregistered client $ renderServiceName item
+            removedHosts <- filterDeadService name notifierHosts
+            unless (null removedHosts) $
               logInfo $
-                printf "Restored %d cached items and %d cached hosts."
-                  (length restoredItems)
-                  (length restoredHosts)
-              mapM_ (emitStatusNotifierItemRegistered client . renderServiceName)
-                restoredItems
-              mapM_ (const $ emitStatusNotifierHostRegistered client) restoredHosts
-          _ -> stopWatcher
-        return nameRequestResult
+                printf "Unregistering host %s because it disappeared." name
+            when
+              (not (null removedItems) || not (null removedHosts))
+              persistWatcherState
 
-  return (watcherInterface, startWatcher)
+        watcherMethods =
+          map
+            mkLogMethod
+            [ autoMethodWithMsg
+                "RegisterStatusNotifierItem"
+                registerStatusNotifierItem,
+              autoMethod
+                "RegisterStatusNotifierHost"
+                registerStatusNotifierHost,
+              autoMethod
+                "StopWatcher"
+                stopWatcher,
+              autoMethod
+                "GetObjectPathForItemName"
+                objectPathForItem
+            ]
+
+        watcherProperties =
+          [ mkLogProperty
+              "RegisteredStatusNotifierItems"
+              registeredStatusNotifierItems,
+            mkLogProperty
+              "RegisteredSNIEntries"
+              registeredSNIEntries,
+            mkLogProperty
+              "IsStatusNotifierHostRegistered"
+              isStatusNotifierHostRegistered,
+            mkLogProperty
+              "ProtocolVersion"
+              protocolVersion
+          ]
+
+        watcherInterface =
+          Interface
+            { interfaceName = watcherInterfaceName,
+              interfaceMethods = watcherMethods,
+              interfaceProperties = watcherProperties,
+              interfaceSignals = watcherSignals
+            }
+
+        startWatcher = do
+          nameRequestResult <- requestName client (coerce watcherInterfaceName) []
+          case nameRequestResult of
+            NamePrimaryOwner ->
+              do
+                _ <-
+                  DBusTH.registerForNameOwnerChanged
+                    client
+                    matchAny
+                    handleNameOwnerChanged
+                (restoredItems, restoredHosts) <- restoreWatcherStateFromCache
+                export client (fromString path) watcherInterface
+                logInfo $
+                  printf
+                    "Restored %d cached items and %d cached hosts."
+                    (length restoredItems)
+                    (length restoredHosts)
+                mapM_
+                  (emitStatusNotifierItemRegistered client . renderServiceName)
+                  restoredItems
+                mapM_ (const $ emitStatusNotifierHostRegistered client) restoredHosts
+            _ -> stopWatcher
+          return nameRequestResult
+
+    return (watcherInterface, startWatcher)
 
 -- For Client generation
 -- TODO: get rid of unsafePerformIO here by making function that takes mvars so
 -- IO isn't needed to build watcher
 {-# NOINLINE watcherInterface #-}
 watcherInterface = buildIntrospectionInterface clientInterface
-  where (clientInterface, _) =
-          unsafePerformIO $ buildWatcher
-          defaultWatcherParams { watcherDBusClient = Just undefined }
+  where
+    (clientInterface, _) =
+      unsafePerformIO $
+        buildWatcher
+          defaultWatcherParams {watcherDBusClient = Just undefined}

--- a/packages/status-notifier-item/src/StatusNotifier/Watcher/Signals.hs
+++ b/packages/status-notifier-item/src/StatusNotifier/Watcher/Signals.hs
@@ -1,17 +1,23 @@
 {-# LANGUAGE TemplateHaskell #-}
+
 module StatusNotifier.Watcher.Signals where
 
 import DBus.Generation
 import Language.Haskell.TH
-
 import StatusNotifier.Watcher.Constants
 
 -- The bus name is set to nothing here because sender comes through as the
 -- unique name of the watcher, not the special bus name that it requests.
-generateSignals watcherClientGenerationParams { genBusName = Nothing }
-                defaultWatcherInterfaceName watcherSignals
+generateSignals
+  watcherClientGenerationParams {genBusName = Nothing}
+  defaultWatcherInterfaceName
+  watcherSignals
 
 printWatcherSignals =
-  runQ (generateSignals watcherClientGenerationParams { genBusName = Nothing }
-                defaultWatcherInterfaceName watcherSignals) >>=
-       putStrLn . pprint
+  runQ
+    ( generateSignals
+        watcherClientGenerationParams {genBusName = Nothing}
+        defaultWatcherInterfaceName
+        watcherSignals
+    )
+    >>= putStrLn . pprint

--- a/packages/status-notifier-item/src/StatusNotifier/Watcher/StateCache.hs
+++ b/packages/status-notifier-item/src/StatusNotifier/Watcher/StateCache.hs
@@ -1,45 +1,48 @@
 module StatusNotifier.Watcher.StateCache
-  ( PersistedItemEntry (..)
-  , PersistedWatcherState (..)
-  , defaultWatcherStateCachePath
-  , readPersistedWatcherState
-  , writePersistedWatcherState
-  ) where
+  ( PersistedItemEntry (..),
+    PersistedWatcherState (..),
+    defaultWatcherStateCachePath,
+    readPersistedWatcherState,
+    writePersistedWatcherState,
+  )
+where
 
 import Control.Applicative ((<|>))
 import Control.Exception (IOException, try)
 import Data.Char (isAlphaNum, isDigit)
 import Data.List (intercalate)
 import System.Directory
-  ( XdgDirectory (XdgCache)
-  , createDirectoryIfMissing
-  , doesFileExist
-  , getXdgDirectory
-  , renameFile
+  ( XdgDirectory (XdgCache),
+    createDirectoryIfMissing,
+    doesFileExist,
+    getXdgDirectory,
+    renameFile,
   )
-import System.FilePath ((</>), takeDirectory)
+import System.FilePath (takeDirectory, (</>))
 import Text.ParserCombinators.ReadP
-  ( ReadP
-  , char
-  , choice
-  , eof
-  , many
-  , munch
-  , readP_to_S
-  , satisfy
-  , sepBy
-  , skipSpaces
+  ( ReadP,
+    char,
+    choice,
+    eof,
+    many,
+    munch,
+    readP_to_S,
+    satisfy,
+    sepBy,
+    skipSpaces,
   )
 
 data PersistedItemEntry = PersistedItemEntry
-  { persistedServiceName :: String
-  , persistedServicePath :: String
-  } deriving (Eq, Show)
+  { persistedServiceName :: String,
+    persistedServicePath :: String
+  }
+  deriving (Eq, Show)
 
 data PersistedWatcherState = PersistedWatcherState
-  { persistedItems :: [PersistedItemEntry]
-  , persistedHosts :: [PersistedItemEntry]
-  } deriving (Eq, Show)
+  { persistedItems :: [PersistedItemEntry],
+    persistedHosts :: [PersistedItemEntry]
+  }
+  deriving (Eq, Show)
 
 data JsonValue
   = JsonObject [(String, JsonValue)]
@@ -90,16 +93,16 @@ encodePersistedWatcherState :: PersistedWatcherState -> String
 encodePersistedWatcherState state =
   encodeJsonValue $
     JsonObject
-      [ ("version", JsonNumber 1)
-      , ("items", JsonArray $ map encodeItemEntry (persistedItems state))
-      , ("hosts", JsonArray $ map encodeItemEntry (persistedHosts state))
+      [ ("version", JsonNumber 1),
+        ("items", JsonArray $ map encodeItemEntry (persistedItems state)),
+        ("hosts", JsonArray $ map encodeItemEntry (persistedHosts state))
       ]
 
 encodeItemEntry :: PersistedItemEntry -> JsonValue
 encodeItemEntry entry =
   JsonObject
-    [ ("service_name", JsonString (persistedServiceName entry))
-    , ("service_path", JsonString (persistedServicePath entry))
+    [ ("service_name", JsonString (persistedServiceName entry)),
+      ("service_path", JsonString (persistedServicePath entry))
     ]
 
 decodePersistedWatcherState :: String -> Either String PersistedWatcherState
@@ -114,20 +117,22 @@ decodePersistedWatcherState raw = do
       hostsValue <- getRequired "hosts" rootObject
       items <- asArray "items" itemsValue >>= mapM decodeItemEntry
       hosts <- asArray "hosts" hostsValue >>= mapM decodeItemEntry
-      Right PersistedWatcherState
-        { persistedItems = items
-        , persistedHosts = hosts
-        }
+      Right
+        PersistedWatcherState
+          { persistedItems = items,
+            persistedHosts = hosts
+          }
 
 decodeItemEntry :: JsonValue -> Either String PersistedItemEntry
 decodeItemEntry value = do
   obj <- asObject "entry" value
   serviceName <- getRequiredString "service_name" obj
   servicePath <- getRequiredString "service_path" obj
-  Right PersistedItemEntry
-    { persistedServiceName = serviceName
-    , persistedServicePath = servicePath
-    }
+  Right
+    PersistedItemEntry
+      { persistedServiceName = serviceName,
+        persistedServicePath = servicePath
+      }
 
 encodeJsonValue :: JsonValue -> String
 encodeJsonValue json =
@@ -218,17 +223,17 @@ parseJsonStringChar =
     parseEscaped = do
       _ <- char '\\'
       choice
-        [ '"' <$ char '"'
-        , '\\' <$ char '\\'
-        , '\n' <$ char 'n'
-        , '\r' <$ char 'r'
-        , '\t' <$ char 't'
+        [ '"' <$ char '"',
+          '\\' <$ char '\\',
+          '\n' <$ char 'n',
+          '\r' <$ char 'r',
+          '\t' <$ char 't'
         ]
     parseUnescaped = satisfy (\c -> c /= '"' && c /= '\\')
 
 parseJsonNumber :: ReadP JsonValue
 parseJsonNumber = do
-  sign <- munch (\c -> c == '-')
+  sign <- munch (== '-')
   digits <- munch isDigit
   if null digits || length sign > 1
     then fail "Invalid number"

--- a/packages/status-notifier-item/test/HostSpec.hs
+++ b/packages/status-notifier-item/test/HostSpec.hs
@@ -17,7 +17,7 @@ import Control.Concurrent
     writeChan,
   )
 import Control.Exception (finally)
-import Control.Monad (replicateM, void)
+import Control.Monad (join, replicateM, void)
 import DBus (busName_, interfaceName_, memberName_, objectPath_, signal)
 import DBus.Client
 import qualified DBus.Internal.Message as M
@@ -76,8 +76,8 @@ spec = around withIsolatedSessionBus $ do
       removeUpdateHandler host token
 
       itemClient <- connectSession
-      cleanup <- registerSimpleItem itemClient "org.test.HostItemC" defaultPath "help-about"
-      cleanup
+      join $
+        registerSimpleItem itemClient "org.test.HostItemC" defaultPath "help-about"
 
       noEvent <- timeout 500000 (readChan events)
       noEvent `shouldBe` Nothing

--- a/packages/status-notifier-item/test/Main.hs
+++ b/packages/status-notifier-item/test/Main.hs
@@ -1,8 +1,7 @@
 module Main (main) where
 
-import Test.Hspec
-
 import qualified HostSpec
+import Test.Hspec
 import qualified UtilSpec
 import qualified WatcherSpec
 

--- a/packages/status-notifier-item/test/TestSupport.hs
+++ b/packages/status-notifier-item/test/TestSupport.hs
@@ -2,58 +2,59 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module TestSupport
-  ( withIsolatedSessionBus
-  , startWatcher
-  , registerSimpleItem
-  , connectSessionWithName
-  , waitFor
-  ) where
+  ( withIsolatedSessionBus,
+    startWatcher,
+    registerSimpleItem,
+    connectSessionWithName,
+    waitFor,
+  )
+where
 
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException, displayException, finally, try)
 import Control.Monad (filterM)
 import DBus (BusName, busName_, formatBusName, objectPath_)
 import DBus.Client
-  ( Client
-  , Interface (..)
-  , RequestNameReply (NamePrimaryOwner)
-  , connectSession
-  , connectWithName
-  , defaultClientOptions
-  , export
-  , readOnlyProperty
-  , releaseName
-  , requestName
+  ( Client,
+    Interface (..),
+    RequestNameReply (NamePrimaryOwner),
+    connectSession,
+    connectWithName,
+    defaultClientOptions,
+    export,
+    readOnlyProperty,
+    releaseName,
+    requestName,
   )
 import DBus.Internal.Address (getSessionAddress)
-import StatusNotifier.Watcher.Constants
-  ( defaultWatcherParams
-  , watcherDBusClient
-  , watcherStop
-  )
 import qualified StatusNotifier.Watcher.Client as WatcherClient
+import StatusNotifier.Watcher.Constants
+  ( defaultWatcherParams,
+    watcherDBusClient,
+    watcherStop,
+  )
 import qualified StatusNotifier.Watcher.Service as WatcherService
 import System.Directory
-  ( createDirectory
-  , doesFileExist
-  , findExecutable
-  , getTemporaryDirectory
-  , removeDirectoryRecursive
-  , removeFile
+  ( createDirectory,
+    doesFileExist,
+    findExecutable,
+    getTemporaryDirectory,
+    removeDirectoryRecursive,
+    removeFile,
   )
 import System.Environment (lookupEnv, setEnv, unsetEnv)
-import System.Exit (ExitCode, ExitCode (ExitSuccess))
-import System.FilePath ((</>), takeDirectory)
+import System.Exit (ExitCode (ExitSuccess))
+import System.FilePath (takeDirectory, (</>))
 import System.IO (hClose, openTempFile)
 import System.Process (readProcessWithExitCode)
 import Test.Hspec
 
 data BusEnv = BusEnv
-  { previousAddress :: Maybe String
-  , previousPid :: Maybe String
-  , previousCacheHome :: Maybe String
-  , cacheHome :: FilePath
-  , daemonPid :: String
+  { previousAddress :: Maybe String,
+    previousPid :: Maybe String,
+    previousCacheHome :: Maybe String,
+    cacheHome :: FilePath,
+    daemonPid :: String
   }
 
 findDbusSessionConfig :: IO (Maybe FilePath)
@@ -64,8 +65,8 @@ findDbusSessionConfig = do
     Just exe -> do
       let prefix = takeDirectory (takeDirectory exe)
           candidates =
-            [ prefix </> "share" </> "dbus-1" </> "session.conf"
-            , prefix </> "etc" </> "dbus-1" </> "session.conf"
+            [ prefix </> "share" </> "dbus-1" </> "session.conf",
+              prefix </> "etc" </> "dbus-1" </> "session.conf"
             ]
       existing <- filterM doesFileExist candidates
       pure $ case existing of
@@ -108,13 +109,14 @@ setup = do
       setEnv "DBUS_SESSION_BUS_ADDRESS" address
       setEnv "DBUS_SESSION_BUS_PID" pidLine
       setEnv "XDG_CACHE_HOME" cachePath
-      pure BusEnv
-        { previousAddress = oldAddress
-        , previousPid = oldPid
-        , previousCacheHome = oldCacheHome
-        , cacheHome = cachePath
-        , daemonPid = pidLine
-        }
+      pure
+        BusEnv
+          { previousAddress = oldAddress,
+            previousPid = oldPid,
+            previousCacheHome = oldCacheHome,
+            cacheHome = cachePath,
+            daemonPid = pidLine
+          }
     _ ->
       error $
         "Failed to start test dbus-daemon: exit="
@@ -138,11 +140,12 @@ teardown BusEnv {..} = do
   restore "DBUS_SESSION_BUS_ADDRESS" previousAddress
   restore "DBUS_SESSION_BUS_PID" previousPid
   restore "XDG_CACHE_HOME" previousCacheHome
-  _ <- try (removeDirectoryRecursive cacheHome) ::
-    IO (Either SomeException ())
+  _ <-
+    try (removeDirectoryRecursive cacheHome) ::
+      IO (Either SomeException ())
   pure ()
   where
-    restore key value = maybe (unsetEnv key) (setEnv key) value
+    restore key = maybe (unsetEnv key) (setEnv key)
 
 startWatcher :: IO Client
 startWatcher = do
@@ -150,8 +153,8 @@ startWatcher = do
   (_, startFn) <-
     WatcherService.buildWatcher
       defaultWatcherParams
-        { watcherDBusClient = Just client
-        , watcherStop = pure ()
+        { watcherDBusClient = Just client,
+          watcherStop = pure ()
         }
   reply <- startFn
   reply `shouldBe` NamePrimaryOwner
@@ -166,14 +169,14 @@ registerSimpleItem ::
 registerSimpleItem client busName objectPath iconName = do
   let iface =
         Interface
-          { interfaceName = "org.kde.StatusNotifierItem"
-          , interfaceMethods = []
-          , interfaceProperties =
-              [ readOnlyProperty "IconName" (pure iconName)
-              , readOnlyProperty "OverlayIconName" (pure ("" :: String))
-              , readOnlyProperty "ItemIsMenu" (pure False)
-              ]
-          , interfaceSignals = []
+          { interfaceName = "org.kde.StatusNotifierItem",
+            interfaceMethods = [],
+            interfaceProperties =
+              [ readOnlyProperty "IconName" (pure iconName),
+                readOnlyProperty "OverlayIconName" (pure ("" :: String)),
+                readOnlyProperty "ItemIsMenu" (pure False)
+              ],
+            interfaceSignals = []
           }
       path = objectPath_ objectPath
 

--- a/packages/status-notifier-item/test/UtilSpec.hs
+++ b/packages/status-notifier-item/test/UtilSpec.hs
@@ -69,11 +69,11 @@ spec = do
 mkMethodError :: ErrorName -> M.MethodError
 mkMethodError errName =
   M.MethodError
-    { M.methodErrorName = errName
-    , M.methodErrorSerial = Serial 0
-    , M.methodErrorSender = Nothing
-    , M.methodErrorDestination = Nothing
-    , M.methodErrorBody = []
+    { M.methodErrorName = errName,
+      M.methodErrorSerial = Serial 0,
+      M.methodErrorSender = Nothing,
+      M.methodErrorDestination = Nothing,
+      M.methodErrorBody = []
     }
 
 errorUnknownMethod :: ErrorName

--- a/packages/status-notifier-item/test/WatcherSpec.hs
+++ b/packages/status-notifier-item/test/WatcherSpec.hs
@@ -1,15 +1,15 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module WatcherSpec (spec) where
 
 import Control.Exception (finally)
-import Data.Either (isLeft)
-import Data.List (isPrefixOf)
 import DBus (BusName, busName_, formatBusName, objectPath_)
 import DBus.Client
+import Data.Either (isLeft)
+import Data.List (isPrefixOf)
 import qualified StatusNotifier.Watcher.Client as WatcherClient
 import Test.Hspec
-
 import TestSupport
 
 spec :: Spec
@@ -24,13 +24,13 @@ spec = around withIsolatedSessionBus $ do
       watcher <- startWatcher
       itemClient <- connectSession
       cleanup <- registerSimpleItem itemClient "org.test.ItemA" defaultPath "network-wireless"
-      (do
-        result <- WatcherClient.getRegisteredSNIEntries watcher
-        result `shouldSatisfy` \v ->
-          case v of
+      ( do
+          result <- WatcherClient.getRegisteredSNIEntries watcher
+          result `shouldSatisfy` \case
             Right entries -> any ((== defaultPath) . snd) entries
             Left _ -> False
-        ) `finally` cleanup
+        )
+        `finally` cleanup
 
     it "is idempotent when the same item registers twice" $ \() -> do
       watcher <- startWatcher
@@ -82,16 +82,17 @@ spec = around withIsolatedSessionBus $ do
       mainClient <- connectSession
       (sniClient, sniBusName) <- connectSessionWithName
       let sniPath = objectPath_ "/StatusNotifierItem"
-          sniIface = Interface
-            { interfaceName = "org.kde.StatusNotifierItem"
-            , interfaceMethods = []
-            , interfaceProperties =
-                [ readOnlyProperty "IconName" (pure ("test-icon" :: String))
-                , readOnlyProperty "OverlayIconName" (pure ("" :: String))
-                , readOnlyProperty "ItemIsMenu" (pure False)
-                ]
-            , interfaceSignals = []
-            }
+          sniIface =
+            Interface
+              { interfaceName = "org.kde.StatusNotifierItem",
+                interfaceMethods = [],
+                interfaceProperties =
+                  [ readOnlyProperty "IconName" (pure ("test-icon" :: String)),
+                    readOnlyProperty "OverlayIconName" (pure ("" :: String)),
+                    readOnlyProperty "ItemIsMenu" (pure False)
+                  ],
+                interfaceSignals = []
+              }
           sniNameStr = formatBusName sniBusName
       export sniClient sniPath sniIface
       -- Register using the SNI connection's unique bus name, sent from mainClient
@@ -142,7 +143,7 @@ spec = around withIsolatedSessionBus $ do
       itemClientB <- connectSession
       cleanupA <- registerSimpleItem itemClientA "org.test.ItemE" defaultPath "media-playback-start"
       cleanupB <- registerSimpleItem itemClientB "org.test.ItemF" defaultPath "media-playback-stop"
-      (do
+      ( do
           Right before <- WatcherClient.getRegisteredSNIEntries watcher
           before `shouldContain` [("org.test.ItemE", "/StatusNotifierItem")]
           before `shouldContain` [("org.test.ItemF", "/StatusNotifierItem")]
@@ -156,18 +157,20 @@ spec = around withIsolatedSessionBus $ do
                     && ("org.test.ItemF", "/StatusNotifierItem") `elem` entries
                 Left _ -> False
           stable `shouldBe` True
-        ) `finally` cleanupB
+        )
+        `finally` cleanupB
 
     it "restores live items from cache when the watcher restarts" $ \() -> do
       watcher1 <- startWatcher
       itemClient <- connectSession
       cleanup <- registerSimpleItem itemClient "org.test.RestoreLive" defaultPath "network-wireless"
-      (do
+      ( do
           _ <- releaseName watcher1 "org.kde.StatusNotifierWatcher"
           watcher2 <- startWatcher
           Right entries <- WatcherClient.getRegisteredSNIEntries watcher2
           entries `shouldContain` [("org.test.RestoreLive", "/StatusNotifierItem")]
-        ) `finally` cleanup
+        )
+        `finally` cleanup
 
     it "drops cached items that no longer exist when restarting" $ \() -> do
       watcher1 <- startWatcher
@@ -183,7 +186,7 @@ spec = around withIsolatedSessionBus $ do
       watcher1 <- startWatcher
       itemClient <- connectSession
       cleanup <- registerSimpleItem itemClient "org.test.RestoreDedup" defaultPath "folder"
-      (do
+      ( do
           _ <- releaseName watcher1 "org.kde.StatusNotifierWatcher"
           watcher2 <- startWatcher
           WatcherClient.registerStatusNotifierItem itemClient "org.test.RestoreDedup"
@@ -191,7 +194,8 @@ spec = around withIsolatedSessionBus $ do
           Right entries <- WatcherClient.getRegisteredSNIEntries watcher2
           let matches = filter (== ("org.test.RestoreDedup", "/StatusNotifierItem")) entries
           length matches `shouldBe` 1
-        ) `finally` cleanup
+        )
+        `finally` cleanup
 
 defaultPath :: String
 defaultPath = "/StatusNotifierItem"

--- a/packages/status-notifier-item/tool/Main.hs
+++ b/packages/status-notifier-item/tool/Main.hs
@@ -1,8 +1,8 @@
 module Main where
 
-import StatusNotifier.Watcher.Client
 import DBus.Client
 import Data.String
+import StatusNotifier.Watcher.Client
 
 main = do
   client <- connectSession

--- a/packages/status-notifier-item/watcher/Main.hs
+++ b/packages/status-notifier-item/watcher/Main.hs
@@ -6,13 +6,12 @@ import DBus.Client
 import Data.Semigroup ((<>))
 import Data.Version (showVersion)
 import Options.Applicative
+import Paths_status_notifier_item (version)
 import StatusNotifier.Watcher.Constants
 import StatusNotifier.Watcher.Service
 import System.Log.DBus.Server
 import System.Log.Logger
 import Text.Printf
-
-import Paths_status_notifier_item (version)
 
 getWatcherParams :: String -> String -> Priority -> Maybe FilePath -> IO WatcherParams
 getWatcherParams namespace path priority stateCachePath = do
@@ -22,54 +21,64 @@ getWatcherParams namespace path priority stateCachePath = do
   startLogServer client
   return $
     defaultWatcherParams
-    { watcherNamespace = namespace
-    , watcherPath = path
-    , watcherDBusClient = Just client
-    , watcherStateCachePath = stateCachePath
-    }
+      { watcherNamespace = namespace,
+        watcherPath = path,
+        watcherDBusClient = Just client,
+        watcherStateCachePath = stateCachePath
+      }
 
 watcherParamsParser :: Parser (IO WatcherParams)
-watcherParamsParser = getWatcherParams
-  <$> strOption
-  (  long "namespace"
-  <> short 'n'
-  <> metavar "NAMESPACE"
-  <> value "org.kde"
-  <> help "The namespace the watcher should register at."
-  ) <*> strOption
-  (  long "path"
-  <> short 'p'
-  <> metavar "DBUS-PATH"
-  <> value "/StatusNotifierWatcher"
-  <> help "The path at which to run the watcher."
-  ) <*> option auto
-  (  long "log-level"
-  <> short 'l'
-  <> help "Set the log level"
-  <> metavar "LEVEL"
-  <> value INFO
-  ) <*> optional (strOption
-  (  long "state-cache-path"
-  <> metavar "FILEPATH"
-  <> help "Override the watcher state cache file path."
-  )
-  )
+watcherParamsParser =
+  getWatcherParams
+    <$> strOption
+      ( long "namespace"
+          <> short 'n'
+          <> metavar "NAMESPACE"
+          <> value "org.kde"
+          <> help "The namespace the watcher should register at."
+      )
+    <*> strOption
+      ( long "path"
+          <> short 'p'
+          <> metavar "DBUS-PATH"
+          <> value "/StatusNotifierWatcher"
+          <> help "The path at which to run the watcher."
+      )
+    <*> option
+      auto
+      ( long "log-level"
+          <> short 'l'
+          <> help "Set the log level"
+          <> metavar "LEVEL"
+          <> value INFO
+      )
+    <*> optional
+      ( strOption
+          ( long "state-cache-path"
+              <> metavar "FILEPATH"
+              <> help "Override the watcher state cache file path."
+          )
+      )
 
 versionOption :: Parser (a -> a)
-versionOption = infoOption
-                (printf "status-notifier-watcher %s" $ showVersion version)
-                (  long "version"
-                <> help "Show the version number of status-notifier-watcher"
-                )
+versionOption =
+  infoOption
+    (printf "status-notifier-watcher %s" $ showVersion version)
+    ( long "version"
+        <> help "Show the version number of status-notifier-watcher"
+    )
 
 main :: IO ()
 main = do
-  watcherParams <- join $ execParser $
-                   info (helper <*> versionOption <*> watcherParamsParser)
-                   (  fullDesc
-                   <> progDesc "Run a StatusNotifierWatcher"
-                   )
+  watcherParams <-
+    join $
+      execParser $
+        info
+          (helper <*> versionOption <*> watcherParamsParser)
+          ( fullDesc
+              <> progDesc "Run a StatusNotifierWatcher"
+          )
   stop <- newEmptyMVar
-  (_, startWatcher) <- buildWatcher watcherParams { watcherStop = putMVar stop () }
+  (_, startWatcher) <- buildWatcher watcherParams {watcherStop = putMVar stop ()}
   _ <- startWatcher
   takeMVar stop

--- a/packages/xdg-desktop-entry/Setup.hs
+++ b/packages/xdg-desktop-entry/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/packages/xdg-desktop-entry/src/System/Environment/XDG/DesktopEntry.hs
+++ b/packages/xdg-desktop-entry/src/System/Environment/XDG/DesktopEntry.hs
@@ -1,4 +1,7 @@
 -----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+
 -- |
 -- Module      : System.Environment.XDG.DesktopEntry
 -- Copyright   : 2019 Ivan Malison
@@ -11,47 +14,46 @@
 -- Implementation of version 1.2 of the freedesktop "Desktop Entry
 -- specification", see
 -- https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-1.2.html.
------------------------------------------------------------------------------
-
 module System.Environment.XDG.DesktopEntry
-  ( DesktopEntry(..)
-  , deCommand
-  , deComment
-  , deHasCategory
-  , deIcon
-  , deName
-  , deNoDisplay
-  , deNotShowIn
-  , deOnlyShowIn
-  , getClassNames
-  , getDirectoryEntriesDefault
-  , getDirectoryEntry
-  , getDirectoryEntryDefault
-  , getXDGDataDirs
-  , indexDesktopEntriesBy
-  , indexDesktopEntriesByClassName
-  , listDesktopEntries
-  , readDesktopEntry
-  ) where
+  ( DesktopEntry (..),
+    deCommand,
+    deComment,
+    deHasCategory,
+    deIcon,
+    deName,
+    deNoDisplay,
+    deNotShowIn,
+    deOnlyShowIn,
+    getClassNames,
+    getDirectoryEntriesDefault,
+    getDirectoryEntry,
+    getDirectoryEntryDefault,
+    getXDGDataDirs,
+    indexDesktopEntriesBy,
+    indexDesktopEntriesByClassName,
+    listDesktopEntries,
+    readDesktopEntry,
+  )
+where
 
-import           Control.Monad
-import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Except
-import           Data.Bifunctor (bimap)
-import           Data.Char
-import qualified Data.Ini as Ini
-import           Data.Either
-import           Data.Either.Combinators
+import Control.Monad
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Except
+import Data.Bifunctor (bimap)
+import Data.Char
+import Data.Either
+import Data.Either.Combinators
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Ini as Ini
+import Data.List
+import Data.Maybe
 import qualified Data.MultiMap as MM
-import           Data.List
-import           Data.Maybe
-import           Data.Text (pack, unpack)
-import           Safe
-import           System.Directory
-import           System.FilePath.Posix
-import           Text.Printf
-import           Text.Read (readMaybe)
+import Data.Text (pack, unpack)
+import Safe
+import System.Directory
+import System.FilePath.Posix
+import Text.Printf
+import Text.Read (readMaybe)
 
 data DesktopEntryType = Application | Link | Directory
   deriving (Read, Show, Eq)
@@ -64,30 +66,34 @@ getXDGDataDirs =
 -- | Desktop Entry. All attributes (key-value-pairs) are stored in an
 -- association list.
 data DesktopEntry = DesktopEntry
-  { deType :: DesktopEntryType
-  , deFilename :: FilePath -- ^ unqualified filename, e.g. "firefox.desktop"
-  , deAttributes :: [(String, String)] -- ^ Key-value pairs
-  } deriving (Read, Show, Eq)
+  { deType :: DesktopEntryType,
+    -- | unqualified filename, e.g. "firefox.desktop"
+    deFilename :: FilePath,
+    -- | Key-value pairs
+    deAttributes :: [(String, String)]
+  }
+  deriving (Read, Show, Eq)
 
 -- | Determine whether the Category attribute of a desktop entry contains a
 -- given value.
-deHasCategory
-  :: DesktopEntry
-  -> String
-  -> Bool
+deHasCategory ::
+  DesktopEntry ->
+  String ->
+  Bool
 deHasCategory de cat =
   maybe False ((cat `elem`) . splitAtSemicolon) $
-        lookup "Categories" (deAttributes de)
+    lookup "Categories" (deAttributes de)
 
 splitAtSemicolon :: String -> [String]
 splitAtSemicolon = lines . map (\c -> if c == ';' then '\n' else c)
 
 -- | Return the proper name of the desktop entry, depending on the list of
 -- preferred languages.
-deName
-  :: [String] -- ^ Preferred languages
-  -> DesktopEntry
-  -> String
+deName ::
+  -- | Preferred languages
+  [String] ->
+  DesktopEntry ->
+  String
 deName langs de = fromMaybe (deFilename de) $ deLocalisedAtt langs de "Name"
 
 -- | Return the categories in which the entry shall be shown
@@ -110,72 +116,79 @@ deIcon = deAtt "Icon"
 deNoDisplay :: DesktopEntry -> Bool
 deNoDisplay de = maybe False (("true" ==) . map toLower) $ deAtt "NoDisplay" de
 
-deLocalisedAtt
-  :: [String] -- ^ Preferred languages
-  -> DesktopEntry
-  -> String
-  -> Maybe String
+deLocalisedAtt ::
+  -- | Preferred languages
+  [String] ->
+  DesktopEntry ->
+  String ->
+  Maybe String
 deLocalisedAtt langs de att =
   let localeMatches =
         mapMaybe (\l -> lookup (att ++ "[" ++ l ++ "]") (deAttributes de)) langs
-  in case localeMatches of
-       [] -> lookup att $ deAttributes de
-       (x:_) -> Just x
+   in case localeMatches of
+        [] -> lookup att $ deAttributes de
+        (x : _) -> Just x
 
 -- | Return the proper comment of the desktop entry, depending on the list of
 -- preferred languages.
-deComment :: [String] -- ^ Preferred languages
-          -> DesktopEntry
-          -> Maybe String
+deComment ::
+  -- | Preferred languages
+  [String] ->
+  DesktopEntry ->
+  Maybe String
 deComment langs de = deLocalisedAtt langs de "Comment"
 
 -- | Return the command that should be executed when running this desktop entry.
 deCommand :: DesktopEntry -> Maybe String
 deCommand de =
-  reverse . dropWhile (== ' ') . reverse . takeWhile (/= '%') <$>
-  lookup "Exec" (deAttributes de)
+  reverse . dropWhile (== ' ') . reverse . takeWhile (/= '%')
+    <$> lookup "Exec" (deAttributes de)
 
 -- | Return a list of all desktop entries in the given directory.
-listDesktopEntries
-  :: String -- ^ The extension to use in the search
-  -> FilePath -- ^ The filepath at which to search
-  -> IO [DesktopEntry]
+listDesktopEntries ::
+  -- | The extension to use in the search
+  String ->
+  -- | The filepath at which to search
+  FilePath ->
+  IO [DesktopEntry]
 listDesktopEntries extension dir = do
   let normalizedDir = normalise dir
   ex <- doesDirectoryExist normalizedDir
   if ex
-  then do
-    files <- map (normalizedDir </>) <$> listDirectory dir
-    entries <-
-      (nub . rights) <$>
-      mapM readDesktopEntry (filter (extension `isSuffixOf`) files)
-    subDirs <- filterM doesDirectoryExist files
-    subEntries <- concat <$> mapM (listDesktopEntries extension) subDirs
-    return $ entries ++ subEntries
-  else return []
+    then do
+      files <- map (normalizedDir </>) <$> listDirectory dir
+      entries <-
+        nub . rights
+          <$> mapM readDesktopEntry (filter (extension `isSuffixOf`) files)
+      subDirs <- filterM doesDirectoryExist files
+      subEntries <- concat <$> mapM (listDesktopEntries extension) subDirs
+      return $ entries ++ subEntries
+    else return []
 
 -- XXX: This function doesn't recurse, but `listDesktopEntries` does. Why?
 -- Shouldn't they really share logic...
+
 -- | Retrieve a desktop entry with a specific name.
 getDirectoryEntry :: [FilePath] -> String -> IO (Maybe DesktopEntry)
 getDirectoryEntry dirs name = do
   exFiles <- filterM doesFileExist $ map ((</> name) . normalise) dirs
-  join . (fmap rightToMaybe) <$> traverse readDesktopEntry (headMay exFiles)
+  (rightToMaybe =<<) <$> traverse readDesktopEntry (headMay exFiles)
 
 -- | Get a desktop entry with a specific name from the default directory entry
 -- locations.
 getDirectoryEntryDefault :: String -> IO (Maybe DesktopEntry)
 getDirectoryEntryDefault entry =
-  fmap (</> "applications") <$> getXDGDataDirs >>=
-  flip getDirectoryEntry (printf "%s.desktop" entry)
+  getXDGDataDirs
+    >>= flip getDirectoryEntry (printf "%s.desktop" entry) . fmap (</> "applications")
 
 -- | Get all instances of 'DesktopEntry' for all desktop entry files that can be
 -- found by looking in the directories specified by the XDG specification.
 getDirectoryEntriesDefault :: IO [DesktopEntry]
 getDirectoryEntriesDefault =
-  fmap (</> "applications") <$> getXDGDataDirs >>= foldM addDesktopEntries []
-  where addDesktopEntries soFar directory =
-          (soFar ++) <$> listDesktopEntries "desktop" directory
+  getXDGDataDirs >>= foldM addDesktopEntries [] . fmap (</> "applications")
+  where
+    addDesktopEntries soFar directory =
+      (soFar ++) <$> listDesktopEntries "desktop" directory
 
 -- | Read a desktop entry from a file.
 readDesktopEntry :: FilePath -> IO (Either String DesktopEntry)
@@ -184,34 +197,39 @@ readDesktopEntry filePath = runExceptT $ do
   -- let bar :: ExceptT String IO (HM.HashMap Text [(Text, Text)]) = map Ini.iniSections . liftIO $ Ini.readIniFile filePath
   -- sections <- fmap Ini.iniSections . join . fmap except . liftIO $ Ini.readIniFile filePath
   sections <- liftIO (Ini.readIniFile filePath) >>= fmap Ini.iniSections . except
-  result <- maybe (throwE "Section [Desktop Entry] not found") (pure . fmap (bimap unpack unpack)) $
-              HM.lookup (pack "Desktop Entry") sections
-  return DesktopEntry
-         { deType = fromMaybe Application $ lookup "Type" result >>= readMaybe
-         , deFilename = filePath
-         , deAttributes = result
-         }
+  result <-
+    maybe (throwE "Section [Desktop Entry] not found") (pure . fmap (bimap unpack unpack)) $
+      HM.lookup (pack "Desktop Entry") sections
+  return
+    DesktopEntry
+      { deType = fromMaybe Application $ lookup "Type" result >>= readMaybe,
+        deFilename = filePath,
+        deAttributes = result
+      }
 
 -- | Construct a 'MM.Multimap' where each 'DesktopEntry' in the provided
 -- foldable is indexed by the keys returned from the provided indexing function.
 indexDesktopEntriesBy ::
-  Foldable t => (DesktopEntry -> [String]) ->
-  t DesktopEntry -> MM.MultiMap String DesktopEntry
+  (Foldable t) =>
+  (DesktopEntry -> [String]) ->
+  t DesktopEntry ->
+  MM.MultiMap String DesktopEntry
 indexDesktopEntriesBy getIndices = foldl insertByIndices MM.empty
   where
     insertByIndices entriesMap entry =
       foldl insertForKey entriesMap $ getIndices entry
-        where insertForKey innerMap key = MM.insert key entry innerMap
+      where
+        insertForKey innerMap key = MM.insert key entry innerMap
 
 -- | Get all the text elements that could be interpreted as class names from a
 -- 'DesktopEntry'.
 getClassNames :: DesktopEntry -> [String]
-getClassNames DesktopEntry { deAttributes = attributes, deFilename = filepath } =
-  (snd $ splitExtensions $ snd $ splitFileName filepath) :
-  catMaybes [lookup "StartupWMClass" attributes, lookup "Name" attributes]
+getClassNames DesktopEntry {deAttributes = attributes, deFilename = filepath} =
+  snd (splitExtensions $ snd $ splitFileName filepath)
+    : catMaybes [lookup "StartupWMClass" attributes, lookup "Name" attributes]
 
 -- | Construct a multimap where desktop entries are indexed by their class
 -- names.
-indexDesktopEntriesByClassName
-  :: Foldable t => t DesktopEntry -> MM.MultiMap String DesktopEntry
+indexDesktopEntriesByClassName ::
+  (Foldable t) => t DesktopEntry -> MM.MultiMap String DesktopEntry
 indexDesktopEntriesByClassName = indexDesktopEntriesBy getClassNames

--- a/packages/xdg-desktop-entry/test/Main.hs
+++ b/packages/xdg-desktop-entry/test/Main.hs
@@ -6,13 +6,11 @@ import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 fileContent :: [String]
-fileContent = [
-    "[Desktop Entry]\n\
+fileContent =
+  [ "[Desktop Entry]\n\
     \Icon=1",
-
     "[Desktop Entry]\n\
     \icon=2",
-
     "[desktop entry]\n\
     \Icon=3"
   ]
@@ -21,7 +19,7 @@ main :: IO ()
 main = withSystemTempDirectory "xdg-desktop-entry" $ \dir -> do
   let filepath :: Int -> String
       filepath i = dir </> show i
-  for_ (zip [0::Int ..] fileContent) $ \(i, content) -> do
+  for_ (zip [0 :: Int ..] fileContent) $ \(i, content) -> do
     print i
     writeFile (filepath i) content
   hspec $ do

--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -153,6 +153,7 @@ import System.FilePath (normalise, splitSearchPath, takeDirectory, takeFileName,
 import qualified System.IO as IO
 import System.Log.Logger
 import System.Taffybar.Context
+import System.Taffybar.Context.Backend (prepareBackendEnvironment)
 import System.Taffybar.Hooks
 import System.Taffybar.Util (maybeHandleSigHUP, onSigINT, rebracket_)
 
@@ -340,13 +341,14 @@ startTaffybar config = do
   setTaffyLogFormatter "System.Taffybar"
   setTaffyLogFormatter "StatusNotifier"
 
-  -- Detect backend once up-front so any environment fixups happen before GTK
-  -- initialization, and so we don't have multiple ad-hoc checks spread around.
-  backendType <- detectBackend
-  when (backendType == BackendX11) $ void initThreads
+  -- Fix up stale session-manager environment before GTK/GDK choose a display,
+  -- then use GDK's actual opened display as the source of truth.
+  prepareBackendEnvironment
+  void initThreads
 
   _ <- Gtk.init Nothing
   GIThreading.setCurrentThreadAsGUIThread
+  backendType <- detectBackend
 
   cssPathsToLoad <- getCSSPaths config
   context <- buildContextWithBackend backendType config

--- a/src/System/Taffybar/Context.hs
+++ b/src/System/Taffybar/Context.hs
@@ -76,11 +76,12 @@ where
 import Control.Arrow ((&&&), (***))
 import Control.Concurrent (forkIO, threadDelay)
 import qualified Control.Concurrent.MVar as MV
-import Control.Concurrent.STM.TChan (TChan)
+import Control.Concurrent.STM.TChan (TChan, readTChan)
 import Control.Exception (SomeException, try)
 import Control.Exception.Enclosed (catchAny)
 import Control.Monad
 import Control.Monad.IO.Class
+import Control.Monad.STM (atomically)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
@@ -364,6 +365,9 @@ buildContextWithBackend
       startup
       logC DEBUG "Queing build windows command"
       refreshTaffyWindows
+      when (backendType == BackendWayland) $
+        liftIO $
+          registerHyprlandReconnectRefresh context
     logIO DEBUG "Context build finished"
     return context
 
@@ -411,6 +415,49 @@ registerResumeRefresh ctx = do
         "Failed to register logind PrepareForSleep handler (resume refresh disabled): "
           ++ show e
     Right _ -> pure ()
+
+-- | Recreate Wayland bar windows when the Hyprland event socket reconnects.
+--
+-- Hyprland restarts can leave existing layer-shell surfaces invisible even
+-- though the taffybar process and widget state loops are still alive. The
+-- Hyprland event reader emits @taffybar-hyprland-connected@ after every event
+-- socket connection, so use reconnects as the compositor-lifecycle signal and
+-- force a top-level window refresh.
+registerHyprlandReconnectRefresh :: Context -> IO ()
+registerHyprlandReconnectRefresh ctx = do
+  eventChan <- withHyprlandEventChan ctx
+  events <- subscribeHyprlandEvents eventChan
+  readyVar <- MV.newMVar False
+  pendingVar <- MV.newMVar False
+  void $ forkIO $ do
+    -- The event reader also emits a connection event during normal startup.
+    -- Ignore early connection events so startup does not immediately rebuild
+    -- the windows it just created.
+    threadDelay 2_000_000
+    void $ MV.swapMVar readyVar True
+
+  let isConnectedEvent line =
+        T.takeWhile (/= '>') line == "taffybar-hyprland-connected"
+
+      scheduleRefresh = do
+        wasPending <- MV.swapMVar pendingVar True
+        unless wasPending $ void $ forkIO $ do
+          -- Give Hyprland/GDK a short settling window before rebuilding
+          -- layer-shell surfaces.
+          threadDelay 1_000_000
+          _ <- MV.swapMVar pendingVar False
+          logIO NOTICE "Hyprland event socket reconnected - forcing taffybar window refresh"
+          postGUIASync $ runReaderT forceRefreshTaffyWindows ctx
+
+      handleConnectedEvent = do
+        ready <- MV.readMVar readyVar
+        if ready
+          then scheduleRefresh
+          else logIO DEBUG "Ignoring Hyprland event socket connection during startup"
+
+  void $ forkIO $ forever $ do
+    line <- atomically $ readTChan events
+    when (isConnectedEvent line) handleConnectedEvent
 
 -- | Build an empty taffybar context. This function is mostly useful for
 -- invoking functions that yield 'TaffyIO' values in a testing setting (e.g. in

--- a/src/System/Taffybar/Context/Backend.hs
+++ b/src/System/Taffybar/Context/Backend.hs
@@ -33,6 +33,7 @@ import Control.Exception.Enclosed (catchAny)
 import Control.Monad
 import Data.GI.Base (castTo)
 import Data.List (isPrefixOf, isSuffixOf)
+import Data.Maybe (isJust)
 import qualified Data.Text as T
 import qualified GI.Gdk as Gdk
 import qualified GI.GdkX11.Objects.X11Display as GdkX11
@@ -185,7 +186,7 @@ detectBackendFromGdk = do
     Nothing -> pure Nothing
     Just display -> do
       displayName <- Gdk.displayGetName display
-      isX11 <- maybe False (const True) <$> castTo GdkX11.X11Display display
+      isX11 <- isJust <$> castTo GdkX11.X11Display display
       let selected =
             if isX11
               then BackendX11
@@ -234,6 +235,4 @@ detectBackend :: IO Backend
 detectBackend = do
   prepareBackendEnvironment
   mGdkBackend <- detectBackendFromGdk
-  case mGdkBackend of
-    Just backend -> pure backend
-    Nothing -> detectBackendFromEnvironment
+  maybe detectBackendFromEnvironment pure mGdkBackend

--- a/src/System/Taffybar/Context/Backend.hs
+++ b/src/System/Taffybar/Context/Backend.hs
@@ -20,6 +20,8 @@
 module System.Taffybar.Context.Backend
   ( Backend (..),
     detectBackend,
+    detectBackendFromGdk,
+    prepareBackendEnvironment,
 
     -- * Discovery helpers
     discoverWaylandSocket,
@@ -29,7 +31,11 @@ where
 
 import Control.Exception.Enclosed (catchAny)
 import Control.Monad
+import Data.GI.Base (castTo)
 import Data.List (isPrefixOf, isSuffixOf)
+import qualified Data.Text as T
+import qualified GI.Gdk as Gdk
+import qualified GI.GdkX11.Objects.X11Display as GdkX11
 import System.Directory (doesPathExist, listDirectory)
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import System.FilePath ((</>))
@@ -65,16 +71,15 @@ discoverWaylandSocket runtime = do
   where
     go [] = pure Nothing
     go (c : cs) = do
-      ok <-
-        catchAny
-          (isSocket <$> getFileStatus (runtime </> c))
-          (const $ pure False)
+      ok <- isSocketPath (runtime </> c)
       if ok then pure (Just c) else go cs
 
 -- | Try to find a Hyprland instance signature in @XDG_RUNTIME_DIR/hypr/@.
 --
 -- Hyprland creates a directory named after its instance signature under
--- @$XDG_RUNTIME_DIR/hypr/@ containing @hyprland.lock@.
+-- @$XDG_RUNTIME_DIR/hypr/@ containing live command/event sockets. Stale
+-- instance directories can remain after a compositor exits, so lock files are
+-- not sufficient evidence that Hyprland is the active session.
 discoverHyprlandSignature :: FilePath -> IO (Maybe String)
 discoverHyprlandSignature runtime = do
   let hyprDir = runtime </> "hypr"
@@ -87,8 +92,23 @@ discoverHyprlandSignature runtime = do
   where
     go _ [] = pure Nothing
     go hyprDir (e : es) = do
-      isSig <- doesPathExist (hyprDir </> e </> "hyprland.lock")
+      isSig <- isLiveHyprlandSignature (hyprDir </> e)
       if isSig then pure (Just e) else go hyprDir es
+
+isSocketPath :: FilePath -> IO Bool
+isSocketPath path =
+  catchAny
+    (isSocket <$> getFileStatus path)
+    (const $ pure False)
+
+isLiveHyprlandSignature :: FilePath -> IO Bool
+isLiveHyprlandSignature dir =
+  (||)
+    <$> isSocketPath (dir </> ".socket.sock")
+    <*> isSocketPath (dir </> ".socket2.sock")
+
+envIsNonEmpty :: Maybe String -> Bool
+envIsNonEmpty = maybe False (not . null)
 
 -- | Detect the display-server backend, compensating for stale or missing
 -- environment variables.
@@ -104,19 +124,32 @@ discoverHyprlandSignature runtime = do
 --   or empty even though a Wayland compositor is running (e.g. after switching
 --   from an X11 session).
 --
--- This function discovers the real state by probing @XDG_RUNTIME_DIR@, fixes
--- up the process environment so downstream code sees consistent values, and
--- returns the appropriate 'Backend'.
-detectBackend :: IO Backend
-detectBackend = do
+-- This function probes @XDG_RUNTIME_DIR@ only when the current process
+-- environment does not already identify an active X11 session, then fixes up
+-- the process environment so GDK sees consistent display variables.
+prepareBackendEnvironment :: IO ()
+prepareBackendEnvironment = do
   mRuntime <- lookupEnv "XDG_RUNTIME_DIR"
   mDisplay <- lookupEnv "DISPLAY"
   mSessionType <- lookupEnv "XDG_SESSION_TYPE"
+  rawWaylandDisplay <- lookupEnv "WAYLAND_DISPLAY"
+
+  let hasDisplay = envIsNonEmpty mDisplay
+      explicitX11Session = mSessionType == Just "x11" && hasDisplay
+
+  -- If the process environment identifies the active session as X11, trust it
+  -- over ambient Wayland sockets in XDG_RUNTIME_DIR. Those sockets can outlive
+  -- or coexist with a different login session and are not sufficient evidence
+  -- that this process should initialize GTK as Wayland.
+  when explicitX11Session $ do
+    unsetEnv "WAYLAND_DISPLAY"
+    unsetEnv "HYPRLAND_INSTANCE_SIGNATURE"
+    logIO DEBUG "X11 session detected; ignoring ambient Wayland sockets"
 
   -- Discover and fix up WAYLAND_DISPLAY if it is missing or empty.
-  mWaylandDisplay <- do
-    raw <- lookupEnv "WAYLAND_DISPLAY"
-    case (mRuntime, raw) of
+  void $ do
+    case (mRuntime, rawWaylandDisplay) of
+      _ | explicitX11Session -> pure Nothing
       (Just runtime, val) | maybe True null val -> do
         mSock <- discoverWaylandSocket runtime
         case mSock of
@@ -124,11 +157,11 @@ detectBackend = do
             logIO INFO $ "Discovered wayland socket: " ++ sock
             setEnv "WAYLAND_DISPLAY" sock
             pure (Just sock)
-          Nothing -> pure raw
-      _ -> pure raw
+          Nothing -> pure rawWaylandDisplay
+      _ -> pure rawWaylandDisplay
 
   -- Discover and fix up HYPRLAND_INSTANCE_SIGNATURE if it is missing or empty.
-  do
+  unless explicitX11Session $ do
     raw <- lookupEnv "HYPRLAND_INSTANCE_SIGNATURE"
     case (mRuntime, raw) of
       (Just runtime, val) | maybe True null val -> do
@@ -140,6 +173,37 @@ detectBackend = do
           Nothing -> pure ()
       _ -> pure ()
 
+-- | Detect the backend from the display that GDK actually opened.
+--
+-- This should be preferred after @Gtk.init@. Before GTK/GDK initialization,
+-- 'Gdk.displayGetDefault' usually returns 'Nothing', so callers still need
+-- 'prepareBackendEnvironment' to steer GDK toward the intended display.
+detectBackendFromGdk :: IO (Maybe Backend)
+detectBackendFromGdk = do
+  mDisplay <- Gdk.displayGetDefault
+  case mDisplay of
+    Nothing -> pure Nothing
+    Just display -> do
+      displayName <- Gdk.displayGetName display
+      isX11 <- maybe False (const True) <$> castTo GdkX11.X11Display display
+      let selected =
+            if isX11
+              then BackendX11
+              else BackendWayland
+      logIO INFO $
+        "Detected backend from GDK display "
+          ++ T.unpack displayName
+          ++ ": "
+          ++ show selected
+      pure $ Just selected
+
+detectBackendFromEnvironment :: IO Backend
+detectBackendFromEnvironment = do
+  mRuntime <- lookupEnv "XDG_RUNTIME_DIR"
+  mDisplay <- lookupEnv "DISPLAY"
+  mSessionType <- lookupEnv "XDG_SESSION_TYPE"
+  mWaylandDisplay <- lookupEnv "WAYLAND_DISPLAY"
+
   -- Validate the wayland socket.
   let mWaylandPath = do
         runtime <- mRuntime
@@ -149,10 +213,7 @@ detectBackend = do
 
   waylandOk <- case mWaylandPath of
     Nothing -> pure False
-    Just wlPath ->
-      catchAny
-        (isSocket <$> getFileStatus wlPath)
-        (const $ pure False)
+    Just wlPath -> isSocketPath wlPath
 
   -- Clean up the environment when falling back to X11.
   when (not waylandOk && maybe False (not . null) mDisplay) $ do
@@ -166,5 +227,13 @@ detectBackend = do
     setEnv "XDG_SESSION_TYPE" "wayland"
 
   let selected = if waylandOk then BackendWayland else BackendX11
-  logIO INFO $ "Detected backend: " ++ show selected
+  logIO INFO $ "Detected backend from environment: " ++ show selected
   pure selected
+
+detectBackend :: IO Backend
+detectBackend = do
+  prepareBackendEnvironment
+  mGdkBackend <- detectBackendFromGdk
+  case mGdkBackend of
+    Just backend -> pure backend
+    Nothing -> detectBackendFromEnvironment

--- a/src/System/Taffybar/Information/Layout/Hyprland.hs
+++ b/src/System/Taffybar/Information/Layout/Hyprland.hs
@@ -37,12 +37,11 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import System.Log.Logger (Priority (..), logM)
 import System.Taffybar.Context (TaffyIO, getStateDefault, taffyFork)
-import System.Taffybar.Hyprland (getHyprlandEventChan)
+import System.Taffybar.Hyprland (getHyprlandClient, getHyprlandEventChan)
 import qualified System.Taffybar.Information.Hyprland as Hypr
 import qualified System.Taffybar.Information.Hyprland.API as HyprAPI
 import qualified System.Taffybar.Information.Hyprland.Types as HyprTypes
 import System.Taffybar.Information.Layout.Model
-import System.Taffybar.Hyprland (getHyprlandClient)
 
 data HyprlandLayoutProviderConfig = HyprlandLayoutProviderConfig
   { layoutSnapshotGetter :: TaffyIO T.Text,

--- a/src/System/Taffybar/Widget/OpenAIUsage.hs
+++ b/src/System/Taffybar/Widget/OpenAIUsage.hs
@@ -1,0 +1,274 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Widget for displaying OpenAI Codex subscription usage.
+--
+-- This currently uses the same ChatGPT OAuth token file that Codex writes at
+-- @$CODEX_HOME/auth.json@ or @~/.codex/auth.json@ and calls ChatGPT's Codex
+-- usage endpoint. The endpoint is not part of the public OpenAI API, so the
+-- auth and endpoint pieces are configurable.
+module System.Taffybar.Widget.OpenAIUsage
+  ( OpenAIUsageWidgetConfig (..),
+    OpenAIUsageAuth (..),
+    defaultOpenAIUsageWidgetConfig,
+    openAIUsageNew,
+    openAIUsageNewWith,
+  )
+where
+
+import Control.Exception (SomeException, try)
+import Control.Monad.IO.Class (MonadIO)
+import Data.Aeson
+import qualified Data.ByteString.Lazy as LBS
+import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import GI.Gtk (Widget)
+import Network.HTTP.Simple
+import System.Directory (doesFileExist, getHomeDirectory)
+import System.Environment (lookupEnv)
+import System.FilePath ((</>))
+import System.Log.Logger (Priority (ERROR), logM)
+import System.Taffybar.Widget.Generic.PollingLabel
+  ( pollingLabelWithVariableDelayAndRefresh,
+  )
+import System.Taffybar.Widget.Util (widgetSetClassGI)
+import Text.Printf (printf)
+
+data OpenAIUsageWidgetConfig = OpenAIUsageWidgetConfig
+  { openAIUsagePollInterval :: Double,
+    openAIUsageEndpoint :: String,
+    openAIUsageUserAgent :: String,
+    openAIUsageAuthPath :: Maybe FilePath,
+    openAIUsageFallbackLabel :: T.Text
+  }
+
+defaultOpenAIUsageWidgetConfig :: OpenAIUsageWidgetConfig
+defaultOpenAIUsageWidgetConfig =
+  OpenAIUsageWidgetConfig
+    { openAIUsagePollInterval = 60 * 5,
+      openAIUsageEndpoint = "https://chatgpt.com/backend-api/codex/usage",
+      openAIUsageUserAgent = "taffybar-openai-usage",
+      openAIUsageAuthPath = Nothing,
+      openAIUsageFallbackLabel = "AI n/a"
+    }
+
+data OpenAIUsageAuth = OpenAIUsageAuth
+  { openAIUsageAccessToken :: T.Text,
+    openAIUsageAccountId :: T.Text
+  }
+
+instance FromJSON OpenAIUsageAuth where
+  parseJSON = withObject "OpenAIUsageAuth" $ \root -> do
+    tokens <- root .: "tokens"
+    OpenAIUsageAuth
+      <$> tokens .: "access_token"
+      <*> tokens .: "account_id"
+
+data UsageResponse = UsageResponse
+  { usagePlanType :: Maybe T.Text,
+    usageRateLimit :: RateLimit,
+    usageAdditionalRateLimits :: [AdditionalRateLimit],
+    usageCredits :: Maybe Credits,
+    usageReachedType :: Maybe T.Text
+  }
+
+instance FromJSON UsageResponse where
+  parseJSON = withObject "UsageResponse" $ \o ->
+    UsageResponse
+      <$> o .:? "plan_type"
+      <*> o .: "rate_limit"
+      <*> o .:? "additional_rate_limits" .!= []
+      <*> o .:? "credits"
+      <*> o .:? "rate_limit_reached_type"
+
+data AdditionalRateLimit = AdditionalRateLimit
+  { additionalLimitName :: Maybe T.Text,
+    additionalRateLimit :: RateLimit
+  }
+
+instance FromJSON AdditionalRateLimit where
+  parseJSON = withObject "AdditionalRateLimit" $ \o ->
+    AdditionalRateLimit
+      <$> o .:? "limit_name"
+      <*> o .: "rate_limit"
+
+data RateLimit = RateLimit
+  { rateLimitAllowed :: Bool,
+    rateLimitReached :: Bool,
+    rateLimitPrimaryWindow :: Maybe RateLimitWindow,
+    rateLimitSecondaryWindow :: Maybe RateLimitWindow
+  }
+
+instance FromJSON RateLimit where
+  parseJSON = withObject "RateLimit" $ \o ->
+    RateLimit
+      <$> o .:? "allowed" .!= True
+      <*> o .:? "limit_reached" .!= False
+      <*> o .:? "primary_window"
+      <*> o .:? "secondary_window"
+
+data RateLimitWindow = RateLimitWindow
+  { windowUsedPercent :: Int,
+    windowDurationSeconds :: Maybe Int,
+    windowResetAfterSeconds :: Maybe Int
+  }
+
+instance FromJSON RateLimitWindow where
+  parseJSON = withObject "RateLimitWindow" $ \o ->
+    RateLimitWindow
+      <$> o .: "used_percent"
+      <*> o .:? "limit_window_seconds"
+      <*> o .:? "reset_after_seconds"
+
+data Credits = Credits
+  { creditsHasCredits :: Bool,
+    creditsUnlimited :: Bool,
+    creditsBalance :: Maybe T.Text
+  }
+
+instance FromJSON Credits where
+  parseJSON = withObject "Credits" $ \o ->
+    Credits
+      <$> o .:? "has_credits" .!= False
+      <*> o .:? "unlimited" .!= False
+      <*> o .:? "balance"
+
+openAIUsageNew :: (MonadIO m) => m Widget
+openAIUsageNew = openAIUsageNewWith defaultOpenAIUsageWidgetConfig
+
+openAIUsageNewWith :: (MonadIO m) => OpenAIUsageWidgetConfig -> m Widget
+openAIUsageNewWith config =
+  pollingLabelWithVariableDelayAndRefresh action True
+    >>= (`widgetSetClassGI` "openai-usage")
+  where
+    action = do
+      result <- try $ fetchAndFormatUsage config
+      case result of
+        Right formatted -> return formatted
+        Left (err :: SomeException) -> do
+          logM "System.Taffybar.Widget.OpenAIUsage" ERROR (show err)
+          return
+            ( openAIUsageFallbackLabel config,
+              Just "Unable to fetch OpenAI usage",
+              min 60 (openAIUsagePollInterval config)
+            )
+
+fetchAndFormatUsage :: OpenAIUsageWidgetConfig -> IO (T.Text, Maybe T.Text, Double)
+fetchAndFormatUsage config = do
+  auth <- readOpenAIUsageAuth config
+  usage <- fetchUsage config auth
+  let label = formatUsageLabel usage
+      tooltip = formatUsageTooltip usage
+  return (label, Just tooltip, openAIUsagePollInterval config)
+
+readOpenAIUsageAuth :: OpenAIUsageWidgetConfig -> IO OpenAIUsageAuth
+readOpenAIUsageAuth config = do
+  path <- maybe defaultCodexAuthPath return (openAIUsageAuthPath config)
+  bytes <- LBS.readFile path
+  either fail return $ eitherDecode bytes
+
+defaultCodexAuthPath :: IO FilePath
+defaultCodexAuthPath = do
+  codexHome <- lookupEnv "CODEX_HOME"
+  case codexHome of
+    Just dir -> return $ dir </> "auth.json"
+    Nothing -> do
+      home <- getHomeDirectory
+      let path = home </> ".codex" </> "auth.json"
+      exists <- doesFileExist path
+      if exists
+        then return path
+        else fail "No Codex auth file found"
+
+fetchUsage :: OpenAIUsageWidgetConfig -> OpenAIUsageAuth -> IO UsageResponse
+fetchUsage config auth = do
+  request0 <- parseRequest $ openAIUsageEndpoint config
+  let request =
+        setRequestHeader "Authorization" ["Bearer " <> TE.encodeUtf8 (openAIUsageAccessToken auth)] $
+          setRequestHeader "ChatGPT-Account-Id" [TE.encodeUtf8 (openAIUsageAccountId auth)] $
+            setRequestHeader "Accept" ["application/json"] $
+              setRequestHeader "User-Agent" [TE.encodeUtf8 (T.pack (openAIUsageUserAgent config))] request0
+  response <- httpLBS request
+  let statusCode = getResponseStatusCode response
+      body = getResponseBody response
+  if statusCode >= 200 && statusCode < 300
+    then either fail return $ eitherDecode body
+    else fail $ "OpenAI usage endpoint returned HTTP " <> show statusCode
+
+formatUsageLabel :: UsageResponse -> T.Text
+formatUsageLabel usage =
+  let percentText = maybe "n/a" (T.pack . printf "%d%%") $ usagePercent usage
+      reached = rateLimitReached (usageRateLimit usage) || isJust (usageReachedType usage)
+   in (if reached then "AI ! " else "AI ") <> percentText
+
+formatUsageTooltip :: UsageResponse -> T.Text
+formatUsageTooltip usage =
+  T.intercalate "\n" $
+    catMaybes
+      [ ("Plan: " <>) <$> usagePlanType usage,
+        Just $ "Default: " <> formatRateLimit (usageRateLimit usage),
+        formatAdditional <$> listToMaybe (usageAdditionalRateLimits usage),
+        formatCredits <$> usageCredits usage,
+        ("Reached: " <>) <$> usageReachedType usage
+      ]
+
+usagePercent :: UsageResponse -> Maybe Int
+usagePercent usage =
+  maximumMaybe $
+    windowPercents (usageRateLimit usage)
+      <> concatMap (windowPercents . additionalRateLimit) (usageAdditionalRateLimits usage)
+
+windowPercents :: RateLimit -> [Int]
+windowPercents limit =
+  map windowUsedPercent $
+    catMaybes [rateLimitPrimaryWindow limit, rateLimitSecondaryWindow limit]
+
+maximumMaybe :: (Ord a) => [a] -> Maybe a
+maximumMaybe [] = Nothing
+maximumMaybe values = Just $ maximum values
+
+formatAdditional :: AdditionalRateLimit -> T.Text
+formatAdditional additional =
+  fromMaybe "Additional" (additionalLimitName additional)
+    <> ": "
+    <> formatRateLimit (additionalRateLimit additional)
+
+formatRateLimit :: RateLimit -> T.Text
+formatRateLimit limit =
+  let windows =
+        T.intercalate
+          ", "
+          ( mapMaybe
+              (uncurry formatWindow)
+              [ ("short", rateLimitPrimaryWindow limit),
+                ("long", rateLimitSecondaryWindow limit)
+              ]
+          )
+      status
+        | rateLimitReached limit = "reached"
+        | not (rateLimitAllowed limit) = "blocked"
+        | otherwise = "allowed"
+   in windows <> " (" <> status <> ")"
+
+formatWindow :: T.Text -> Maybe RateLimitWindow -> Maybe T.Text
+formatWindow _ Nothing = Nothing
+formatWindow name (Just window) =
+  Just $
+    name
+      <> " "
+      <> T.pack (printf "%d%%" (windowUsedPercent window))
+      <> maybe "" ((" / " <>) . formatDuration) (windowDurationSeconds window)
+      <> maybe "" ((", resets in " <>) . formatDuration) (windowResetAfterSeconds window)
+
+formatCredits :: Credits -> T.Text
+formatCredits credits =
+  "Credits: "
+    <> (if creditsUnlimited credits then "unlimited" else fromMaybe "0" (creditsBalance credits))
+    <> if creditsHasCredits credits then " available" else ""
+
+formatDuration :: Int -> T.Text
+formatDuration seconds
+  | seconds < 60 = T.pack $ printf "%ds" seconds
+  | seconds < 3600 = T.pack $ printf "%dm" (seconds `div` 60)
+  | seconds < 86400 = T.pack $ printf "%dh" (seconds `div` 3600)
+  | otherwise = T.pack $ printf "%dd" (seconds `div` 86400)

--- a/src/System/Taffybar/Widget/Workspaces.hs
+++ b/src/System/Taffybar/Widget/Workspaces.hs
@@ -52,11 +52,11 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Reader (ask, asks, runReaderT)
 import Data.Default (Default (..))
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Int (Int32)
 import Data.List (elemIndex)
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Data.Word (Word64)
-import Data.Int (Int32)
 import qualified GI.Gdk.Enums as Gdk
 import qualified GI.Gdk.Structs.EventScroll as Gdk
 import qualified GI.GdkPixbuf.Objects.Pixbuf as Gdk

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -210,6 +210,7 @@ library
                  , System.Taffybar.Widget.MPRIS2
                  , System.Taffybar.Widget.NetworkGraph
                  , System.Taffybar.Widget.NetworkManager
+                 , System.Taffybar.Widget.OpenAIUsage
                  , System.Taffybar.Widget.PowerProfiles
                  , System.Taffybar.Widget.Privacy
                  , System.Taffybar.Widget.ScreenLock

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -390,6 +390,7 @@ test-suite unit
                , hspec
                , hspec-core
                , hspec-golden
+               , network
                , taffybar
                , taffybar:testlib
                , typed-process

--- a/test/unit/System/Taffybar/ContextSpec.hs
+++ b/test/unit/System/Taffybar/ContextSpec.hs
@@ -24,18 +24,19 @@ module System.Taffybar.ContextSpec
   )
 where
 
-import Control.Exception (SomeException, catch)
+import Control.Exception (SomeException, bracket, catch)
 import Control.Monad.Trans.Reader (runReaderT)
 import Data.Default (def)
 import Data.Ratio ((%))
 import GHC.Generics (Generic)
 import GI.Gtk (Widget)
+import Network.Socket qualified as Socket
 import System.Directory (createDirectoryIfMissing, getTemporaryDirectory, removePathForcibly)
 import System.FilePath ((</>))
 import System.Taffybar.Context
 import System.Taffybar.SimpleConfig
 import System.Taffybar.Test.DBusSpec (withTestDBus)
-import System.Taffybar.Test.UtilSpec (logSetup, withSetEnv)
+import System.Taffybar.Test.UtilSpec (logSetup, withEnv, withSetEnv)
 import System.Taffybar.Test.XvfbSpec (setDefaultDisplay_, withXdummy)
 import System.Taffybar.Widget.SimpleClock (textClockNewWith)
 import System.Taffybar.Widget.Workspaces (workspacesNew)
@@ -47,6 +48,23 @@ import Test.QuickCheck.Monadic
 spec :: Spec
 spec = logSetup $ sequential $ aroundAll_ withTestDBus $ aroundAll_ (withXdummy . flip setDefaultDisplay_) $ do
   describe "detectBackend" $ do
+    it "prefers an explicit X11 session over a discovered Wayland socket" $ do
+      tmp <- getTemporaryDirectory
+      let runtime = tmp </> "taffybar-test-runtime-x11-with-wayland-socket"
+          wlPath = runtime </> "wayland-0"
+      removePathForcibly runtime `catch` (\(_ :: SomeException) -> pure ())
+      createDirectoryIfMissing True runtime
+      withUnixSocket wlPath
+        $ withEnv
+          [ ("XDG_RUNTIME_DIR", const $ Just runtime),
+            ("DISPLAY", const $ Just ":0"),
+            ("XDG_SESSION_TYPE", const $ Just "x11"),
+            ("WAYLAND_DISPLAY", const Nothing),
+            ("HYPRLAND_INSTANCE_SIGNATURE", const Nothing)
+          ]
+        $ detectBackend `shouldReturn` BackendX11
+      removePathForcibly runtime `catch` (\(_ :: SomeException) -> pure ())
+
     it "falls back to X11 when WAYLAND_DISPLAY is set but the socket is missing" $ do
       tmp <- getTemporaryDirectory
       let runtime = tmp </> "taffybar-test-runtime-missing-socket"
@@ -82,6 +100,17 @@ spec = logSetup $ sequential $ aroundAll_ withTestDBus $ aroundAll_ (withXdummy 
   describe "Fuzz tests" $ do
     prop "eval generators" prop_genSimpleConfig
     xprop "TaffybarConfig" prop_taffybarConfig
+
+------------------------------------------------------------------------
+
+withUnixSocket :: FilePath -> IO a -> IO a
+withUnixSocket path action =
+  bracket
+    (Socket.socket Socket.AF_UNIX Socket.Stream Socket.defaultProtocol)
+    Socket.close
+    $ \sock -> do
+      Socket.bind sock (Socket.SockAddrUnix path)
+      action
 
 ------------------------------------------------------------------------
 

--- a/test/unit/System/Taffybar/Information/Workspaces/EWMHSpec.hs
+++ b/test/unit/System/Taffybar/Information/Workspaces/EWMHSpec.hs
@@ -1,6 +1,5 @@
 module System.Taffybar.Information.Workspaces.EWMHSpec (spec) where
 
-import Data.List (elem)
 import System.Taffybar.Information.Workspaces.EWMH
   ( defaultEWMHWorkspaceProviderConfig,
     workspaceUpdateEvents,


### PR DESCRIPTION
## Summary

- prepare the display environment before GTK initialization, then select the taffybar backend from the GDK display GTK actually opened
- ignore ambient Wayland sockets in explicit X11 sessions and require live Hyprland sockets when discovering Hyprland signatures
- update X11 strut properties from the realized GTK allocation so reserved space matches the actual bar height

## Root Cause

The environment probe could discover a stale or unrelated wayland-* socket under XDG_RUNTIME_DIR while taffybar was running in an X11/xmonad session. That selected the Wayland path, skipped X11 struts, and attempted Hyprland APIs with stale sockets. After forcing X11, the configured strut height could still be smaller than the realized GTK window height, allowing managed windows to overlap the bar.

## Validation

- direnv exec . cabal build lib:taffybar lib:gtk-strut
- direnv exec . cabal test unit --test-options="--match detectBackend"
