### PR TITLE
[codex] Add configurable CSS path loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add Anthropic usage information and an Anthropic usage widget.
 * Expose the new OpenAI and Anthropic usage information/widget modules from
   the library.
+* Add config-level control for loading vendored CSS and opt-in environment
+  overrides for CSS paths.
 
 ## Fixes
 

--- a/src/System/Taffybar.hs
+++ b/src/System/Taffybar.hs
@@ -135,7 +135,6 @@ import qualified Control.Concurrent.MVar as MV
 import Control.Exception (finally)
 import Control.Exception.Enclosed (catchAny)
 import Control.Monad
-import Data.Char (toLower)
 import Data.Function (on)
 import qualified Data.GI.Gtk.Threading as GIThreading
 import Data.List (groupBy, isPrefixOf, sort)
@@ -152,7 +151,7 @@ import System.Environment (lookupEnv)
 import System.Environment.XDG.BaseDir (getUserConfigFile)
 import System.Exit (exitFailure)
 import System.FSNotify (Event (..), EventIsDirectory (..), startManager, stopManager, watchDir)
-import System.FilePath (normalise, splitSearchPath, takeDirectory, takeFileName, (</>))
+import System.FilePath (normalise, takeDirectory, takeFileName, (</>))
 import qualified System.IO as IO
 import System.Log.Logger
 import System.Posix.Files (getFileStatus, isSocket)
@@ -199,37 +198,29 @@ getTaffyFile = getUserConfigFile "taffybar"
 
 -- | Return CSS files which should be loaded for the given config.
 getCSSPaths :: TaffybarConfig -> IO [FilePath]
-getCSSPaths TaffybarConfig {cssPaths} = do
-  disableVendor <- envFlag "TAFFYBAR_DISABLE_VENDOR_CSS"
-  disableUser <- envFlag "TAFFYBAR_DISABLE_USER_CSS"
-  explicitUserCss <- lookupEnv "TAFFYBAR_CSS_PATHS"
-  resolvedUserCss <-
-    if disableUser
-      then pure []
-      else case explicitUserCss of
-        Just rawPaths -> pure $ filter (not . null) (splitSearchPath rawPaths)
-        Nothing -> sequence defaultUserCSS
+getCSSPaths config = flattenCSSPaths <$> (cssPathTransform config =<< getDefaultCSSPaths config)
+
+getDefaultCSSPaths :: TaffybarConfig -> IO CSSPaths
+getDefaultCSSPaths TaffybarConfig {cssPaths, includeVendorCss} = do
   vendorCss <-
-    if disableVendor
-      then pure []
-      else (: []) <$> defaultCSS
-  pure (vendorCss <> resolvedUserCss)
+    if includeVendorCss
+      then (: []) <$> getDataFile "taffybar.css"
+      else pure []
+  userCss <- sequence defaultUserCSS
+  pure
+    CSSPaths
+      { vendorCSSPaths = vendorCss,
+        userCSSPaths = userCss
+      }
   where
-    -- Vendor CSS file, which is always loaded before user's CSS.
-    defaultCSS = getDataFile "taffybar.css"
     -- User's configured CSS files, with XDG config file being the default.
     defaultUserCSS
       | null cssPaths = [getTaffyFile "taffybar.css"]
       | otherwise = map return cssPaths
-    envFlag name = do
-      value <- lookupEnv name
-      pure $
-        case fmap (map toLower) value of
-          Just "1" -> True
-          Just "true" -> True
-          Just "yes" -> True
-          Just "on" -> True
-          _ -> False
+
+flattenCSSPaths :: CSSPaths -> [FilePath]
+flattenCSSPaths CSSPaths {vendorCSSPaths, userCSSPaths} =
+  vendorCSSPaths <> userCSSPaths
 
 -- | Overrides the default GTK theme and settings with CSS styles from
 -- the given files (if they exist).

--- a/src/System/Taffybar/Context.hs
+++ b/src/System/Taffybar/Context.hs
@@ -26,8 +26,10 @@
 module System.Taffybar.Context
   ( -- * Configuration
     TaffybarConfig (..),
+    CSSPaths (..),
     defaultTaffybarConfig,
     appendHook,
+    appendCSSPathTransform,
 
     -- ** Bars
     BarLevelConfig (..),
@@ -211,6 +213,16 @@ instance Eq BarConfig where
 -- | Action that returns the list of bar configurations to realize.
 type BarConfigGetter = TaffyIO [BarConfig]
 
+-- | The resolved CSS paths that taffybar will load.
+--
+-- 'vendorCSSPaths' contains stylesheets shipped with taffybar itself.
+-- 'userCSSPaths' contains stylesheets from the user's config.
+data CSSPaths = CSSPaths
+  { vendorCSSPaths :: [FilePath],
+    userCSSPaths :: [FilePath]
+  }
+  deriving (Eq, Show)
+
 -- | 'TaffybarConfig' provides an advanced interface for configuring taffybar.
 -- Through the 'getBarConfigsParam', it is possible to specify different
 -- taffybar configurations depending on the number of monitors present, and even
@@ -226,6 +238,10 @@ data TaffybarConfig = TaffybarConfig
     -- | A list of 'FilePath' each of which should be loaded as css files at
     -- startup.
     cssPaths :: [FilePath],
+    -- | Whether to load the stylesheet shipped with taffybar before user CSS.
+    includeVendorCss :: Bool,
+    -- | A hook for altering the CSS paths after defaults have been resolved.
+    cssPathTransform :: CSSPaths -> IO CSSPaths,
     -- | A field used (only) by dyre to provide an error message.
     errorMsg :: Maybe String
   }
@@ -238,6 +254,13 @@ appendHook hook config =
     { startupHook = startupHook config >> hook
     }
 
+-- | Append the provided CSS path transform to the given 'TaffybarConfig'.
+appendCSSPathTransform :: (CSSPaths -> IO CSSPaths) -> TaffybarConfig -> TaffybarConfig
+appendCSSPathTransform transform config =
+  config
+    { cssPathTransform = cssPathTransform config >=> transform
+    }
+
 -- | Default values for a 'TaffybarConfig'. Not usuable without at least
 -- properly setting 'getBarConfigsParam'.
 defaultTaffybarConfig :: TaffybarConfig
@@ -247,6 +270,8 @@ defaultTaffybarConfig =
       startupHook = return (),
       getBarConfigsParam = return [],
       cssPaths = [],
+      includeVendorCss = True,
+      cssPathTransform = pure,
       errorMsg = Nothing
     }
 

--- a/src/System/Taffybar/Hooks.hs
+++ b/src/System/Taffybar/Hooks.hs
@@ -33,12 +33,14 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.STM (atomically)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Reader
+import Data.Char (toLower)
 import Data.List (isSuffixOf, nub)
 import qualified Data.MultiMap as MM
 import System.Directory (doesDirectoryExist)
+import System.Environment (lookupEnv)
 import System.Environment.XDG.DesktopEntry
 import System.FSNotify (Event (eventIsDirectory, eventPath), EventIsDirectory (IsFile), startManager, watchDir)
-import System.FilePath ((</>))
+import System.FilePath (splitSearchPath, (</>))
 import System.Log.Logger
 import System.Taffybar.Context
 import System.Taffybar.DBus
@@ -94,6 +96,92 @@ withLogLevels =
   appendHook $
     lift $
       defaultLogLevelsPath >>= loadLogLevelsFromFile
+
+-- | Environment variable names used by 'withCSSPathEnvConfig'.
+--
+-- All fields are optional so callers can opt in to exactly the environment
+-- surface they want to expose.
+data CSSPathEnvConfig = CSSPathEnvConfig
+  { -- | When set, replaces all resolved CSS paths with the path list from this
+    -- environment variable.
+    cssPathsEnvVar :: Maybe String,
+    -- | When set to a truthy value, drops taffybar's vendored CSS paths.
+    disableVendorCssEnvVar :: Maybe String,
+    -- | When set to a truthy value, drops user CSS paths.
+    disableUserCssEnvVar :: Maybe String
+  }
+
+-- | Default environment variable names for CSS path overrides.
+defaultCSSPathEnvConfig :: CSSPathEnvConfig
+defaultCSSPathEnvConfig =
+  CSSPathEnvConfig
+    { cssPathsEnvVar = Just "TAFFYBAR_CSS_PATHS",
+      disableVendorCssEnvVar = Just "TAFFYBAR_DISABLE_VENDOR_CSS",
+      disableUserCssEnvVar = Just "TAFFYBAR_DISABLE_USER_CSS"
+    }
+
+-- | Opt in to CSS path overrides from the environment.
+--
+-- This hook is intentionally not part of the default CSS loading behavior.
+-- Apply it to a 'TaffybarConfig' when runtime environment overrides are wanted.
+withEnvironmentCSSPaths :: TaffybarConfig -> TaffybarConfig
+withEnvironmentCSSPaths = withCSSPathEnvConfig defaultCSSPathEnvConfig
+
+-- | Opt in to CSS path overrides from caller-selected environment variables.
+withCSSPathEnvConfig :: CSSPathEnvConfig -> TaffybarConfig -> TaffybarConfig
+withCSSPathEnvConfig config =
+  appendCSSPathTransform $ applyCSSPathEnvConfig config
+
+applyCSSPathEnvConfig :: CSSPathEnvConfig -> CSSPaths -> IO CSSPaths
+applyCSSPathEnvConfig
+  CSSPathEnvConfig
+    { cssPathsEnvVar = pathsVar,
+      disableVendorCssEnvVar = disableVendorVar,
+      disableUserCssEnvVar = disableUserVar
+    }
+  paths = do
+    overridePaths <- lookupPathListEnv pathsVar
+    disableVendor <- lookupFlagEnv disableVendorVar
+    disableUser <- lookupFlagEnv disableUserVar
+    let CSSPaths vendorPaths userPaths =
+          case overridePaths of
+            Just pathList -> paths {userCSSPaths = pathList}
+            Nothing -> paths
+    pure
+      CSSPaths
+        { vendorCSSPaths =
+            if disableVendor
+              then []
+              else vendorPaths,
+          userCSSPaths =
+            if disableUser
+              then []
+              else userPaths
+        }
+
+lookupPathListEnv :: Maybe String -> IO (Maybe [FilePath])
+lookupPathListEnv Nothing = pure Nothing
+lookupPathListEnv (Just varName) =
+  fmap parseCSSPathList <$> lookupEnv varName
+
+parseCSSPathList :: String -> [FilePath]
+parseCSSPathList =
+  filter (not . null) . splitSearchPath
+
+lookupFlagEnv :: Maybe String -> IO Bool
+lookupFlagEnv Nothing = pure False
+lookupFlagEnv (Just varName) = envFlag varName
+
+envFlag :: String -> IO Bool
+envFlag name = do
+  value <- lookupEnv name
+  pure $
+    case fmap (map toLower) value of
+      Just "1" -> True
+      Just "true" -> True
+      Just "yes" -> True
+      Just "on" -> True
+      _ -> False
 
 newtype DesktopEntryCacheWatch
   = DesktopEntryCacheWatch (IO ())

--- a/src/System/Taffybar/SimpleConfig.hs
+++ b/src/System/Taffybar/SimpleConfig.hs
@@ -95,6 +95,8 @@ data SimpleTaffyConfig = SimpleTaffyConfig
     barLevels :: Maybe [BarLevelConfig],
     -- | List of paths to CSS stylesheets that should be loaded at startup.
     cssPaths :: [FilePath],
+    -- | Whether to load the stylesheet shipped with taffybar before user CSS.
+    includeVendorCss :: Bool,
     -- | Hook to run at taffybar startup.
     startupHook :: TaffyIO ()
   }
@@ -115,6 +117,7 @@ defaultSimpleTaffyConfig =
       endWidgets = [],
       barLevels = Nothing,
       cssPaths = [],
+      includeVendorCss = True,
       startupHook = return ()
     }
 
@@ -173,6 +176,7 @@ toTaffybarConfig conf =
   def
     { BC.getBarConfigsParam = configGetter,
       BC.cssPaths = cssPaths conf,
+      BC.includeVendorCss = includeVendorCss conf,
       BC.startupHook = startupHook conf
     }
   where

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -378,6 +378,7 @@ test-suite unit
                , System.Taffybar.AuthSpec
                , System.Taffybar.AppearanceSpec
                , System.Taffybar.ContextSpec
+               , System.Taffybar.HooksSpec
                , System.Taffybar.Information.CryptoSpec
                , System.Taffybar.Information.LayoutSpec
                , System.Taffybar.Information.Workspaces.EWMHSpec

--- a/test/unit/System/Taffybar/ContextSpec.hs
+++ b/test/unit/System/Taffybar/ContextSpec.hs
@@ -260,6 +260,7 @@ toSimpleConfig GenSimpleConfig {..} =
       endWidgets = map toTaffyWidget end,
       barLevels = Nothing,
       cssPaths = toCssPaths css,
+      includeVendorCss = True,
       startupHook = pure () -- TODO: add something
     }
 

--- a/test/unit/System/Taffybar/HooksSpec.hs
+++ b/test/unit/System/Taffybar/HooksSpec.hs
@@ -1,0 +1,69 @@
+module System.Taffybar.HooksSpec (spec) where
+
+import Control.Exception (bracket)
+import Data.Default (def)
+import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.Taffybar.Context (CSSPaths (..), TaffybarConfig (cssPathTransform))
+import System.Taffybar.Hooks (CSSPathEnvConfig (..), withCSSPathEnvConfig)
+import Test.Hspec
+
+spec :: Spec
+spec =
+  describe "withCSSPathEnvConfig" $ do
+    it "does nothing when configured environment variables are unset" $
+      withUnsetEnv testVars $ do
+        cssPathTransform (withCSSPathEnvConfig testEnvConfig def) testCSSPaths
+          `shouldReturn` testCSSPaths
+
+    it "replaces resolved user CSS paths with the configured path-list variable" $
+      withUnsetEnv testVars $
+        withEnv cssPathsVar (Just "override.css:debug.css") $ do
+          cssPathTransform (withCSSPathEnvConfig testEnvConfig def) testCSSPaths
+            `shouldReturn` CSSPaths ["vendor.css"] ["override.css", "debug.css"]
+
+    it "can drop vendored and user CSS paths independently" $
+      withUnsetEnv testVars $
+        withEnv disableVendorVar (Just "yes") $
+          withEnv disableUserVar (Just "1") $ do
+            cssPathTransform (withCSSPathEnvConfig testEnvConfig def) testCSSPaths
+              `shouldReturn` CSSPaths [] []
+
+testCSSPaths :: CSSPaths
+testCSSPaths =
+  CSSPaths
+    { vendorCSSPaths = ["vendor.css"],
+      userCSSPaths = ["user.css"]
+    }
+
+testEnvConfig :: CSSPathEnvConfig
+testEnvConfig =
+  CSSPathEnvConfig
+    { cssPathsEnvVar = Just cssPathsVar,
+      disableVendorCssEnvVar = Just disableVendorVar,
+      disableUserCssEnvVar = Just disableUserVar
+    }
+
+testVars :: [String]
+testVars = [cssPathsVar, disableVendorVar, disableUserVar]
+
+cssPathsVar :: String
+cssPathsVar = "TAFFYBAR_TEST_CSS_PATHS"
+
+disableVendorVar :: String
+disableVendorVar = "TAFFYBAR_TEST_DISABLE_VENDOR_CSS"
+
+disableUserVar :: String
+disableUserVar = "TAFFYBAR_TEST_DISABLE_USER_CSS"
+
+withUnsetEnv :: [String] -> IO a -> IO a
+withUnsetEnv vars action =
+  foldr (\var inner -> withEnv var Nothing inner) action vars
+
+withEnv :: String -> Maybe String -> IO a -> IO a
+withEnv name value action =
+  bracket (lookupEnv name) restoreEnv $ \_ -> do
+    maybe (unsetEnv name) (setEnv name) value
+    action
+  where
+    restoreEnv Nothing = unsetEnv name
+    restoreEnv (Just originalValue) = setEnv name originalValue


### PR DESCRIPTION
## Summary
- separates default CSS path resolution into vendored and user CSS buckets
- adds config-level control for whether vendored CSS is loaded
- moves TAFFYBAR_CSS_PATHS and disable env vars behind an explicit withEnvironmentCSSPaths hook
- adds unit coverage for the environment override semantics

## Motivation
This keeps runtime CSS debug switches available for isolating taffybar flickering without making ambient environment variables affect every taffybar process by default. The existing TAFFYBAR_CSS_PATHS behavior is preserved when the hook is enabled: it replaces user CSS paths while leaving vendored CSS intact unless TAFFYBAR_DISABLE_VENDOR_CSS is also set.

## Validation
- direnv exec . ormolu --mode inplace src/System/Taffybar.hs src/System/Taffybar/Context.hs src/System/Taffybar/Hooks.hs src/System/Taffybar/SimpleConfig.hs test/unit/System/Taffybar/ContextSpec.hs test/unit/System/Taffybar/HooksSpec.hs
- direnv exec . cabal test unit
