### PR TITLE
[codex] Add external workspace icon refresh support

### DIFF
--- a/src/System/Taffybar/Information/ChromeWindowInfo.hs
+++ b/src/System/Taffybar/Information/ChromeWindowInfo.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Event source for the chrome-favicon-bridge D-Bus service.
+module System.Taffybar.Information.ChromeWindowInfo
+  ( registerChromeWindowInfoRefreshRequests,
+  )
+where
+
+import Control.Exception.Enclosed (catchAny)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Reader (ask, asks, runReaderT)
+import qualified DBus as D
+import qualified DBus.Client as DBus
+import qualified Data.Text as T
+import System.Log.Logger (Priority (..), logM)
+import System.Taffybar.Context (TaffyIO, getStateDefault, sessionDBusClient)
+import System.Taffybar.Information.Workspaces.Model
+  ( WindowIdentity (..),
+    WorkspacesRefreshTarget (..),
+  )
+import System.Taffybar.Information.Workspaces.Refresh (requestWorkspacesRefresh)
+
+data ChromeWindowInfoRefreshSubscription
+  = ChromeWindowInfoRefreshSubscription
+
+registerChromeWindowInfoRefreshRequests :: TaffyIO ()
+registerChromeWindowInfoRefreshRequests = do
+  _ <-
+    getStateDefault $
+      buildChromeWindowInfoRefreshSubscription
+        >> return ChromeWindowInfoRefreshSubscription
+  return ()
+
+buildChromeWindowInfoRefreshSubscription :: TaffyIO ()
+buildChromeWindowInfoRefreshSubscription = do
+  ctx <- ask
+  client <- asks sessionDBusClient
+  let requestRefresh target =
+        runReaderT (requestWorkspacesRefresh target) ctx
+  liftIO $
+    ( do
+        registerChromeWindowInfoSignals client requestRefresh
+        logM
+          "System.Taffybar.Information.ChromeWindowInfo"
+          DEBUG
+          "Subscribed to Chrome window info signals"
+    )
+      `catchAny` \err ->
+        chromeWindowInfoLog
+          WARNING
+          ("Failed to subscribe to Chrome window info signals: " <> show err)
+
+registerChromeWindowInfoSignals ::
+  DBus.Client ->
+  (WorkspacesRefreshTarget -> IO ()) ->
+  IO ()
+registerChromeWindowInfoSignals client requestRefresh = do
+  _ <- DBus.addMatch client windowUpdatedRule (emitWindowRefresh requestRefresh)
+  return ()
+  where
+    baseRule =
+      DBus.matchAny
+        { DBus.matchPath = Just "/org/imalison/ChromeWindowInfo",
+          DBus.matchInterface = Just "org.imalison.ChromeWindowInfo"
+        }
+    windowUpdatedRule = baseRule {DBus.matchMember = Just "WindowUpdated"}
+
+emitWindowRefresh :: (WorkspacesRefreshTarget -> IO ()) -> D.Signal -> IO ()
+emitWindowRefresh requestRefresh signal = do
+  let target =
+        case D.signalBody signal of
+          windowIdVariant : _
+            | Just windowId <- D.fromVariant windowIdVariant ->
+                RefreshWindow $ HyprlandWindowIdentity $ normalizeHyprlandWindowId windowId
+          _ -> RefreshAllWorkspaces
+  requestRefresh target
+
+chromeWindowInfoLog :: Priority -> String -> IO ()
+chromeWindowInfoLog =
+  logM "System.Taffybar.Information.ChromeWindowInfo"
+
+normalizeHyprlandWindowId :: T.Text -> T.Text
+normalizeHyprlandWindowId address =
+  let trimmed = T.strip address
+   in if "0x" `T.isPrefixOf` trimmed || T.null trimmed
+        then trimmed
+        else "0x" <> trimmed

--- a/src/System/Taffybar/Information/Workspaces/EWMH.hs
+++ b/src/System/Taffybar/Information/Workspaces/EWMH.hs
@@ -69,6 +69,7 @@ import System.Taffybar.Information.EWMHDesktopInfo
   )
 import System.Taffybar.Information.SafeX11 (safeGetGeometry)
 import System.Taffybar.Information.Workspaces.Model
+import System.Taffybar.Information.Workspaces.Refresh (workspaceRefreshRequestLoop)
 import System.Taffybar.Information.X11DesktopInfo (X11Property, X11Window, getDisplay)
 import qualified System.Taffybar.Information.X11DesktopInfo as X11
 
@@ -168,6 +169,7 @@ buildEWMHWorkspaceStateChanVar cfg = do
   eventChan <- liftIO newBroadcastTChanIO
   stateVar <- liftIO $ newMVar defaultEWMHWorkspaceState
   taffyFork $ ewmhWorkspaceStateLoop cfg stateChan eventChan stateVar
+  taffyFork $ workspaceRefreshRequestLoop stateChan eventChan stateVar
   return $ EWMHWorkspaceStateChanVar (stateChan, eventChan, stateVar)
 
 ewmhWorkspaceStateLoop ::
@@ -223,12 +225,13 @@ refreshEWMHWorkspaceState cfg stateChan eventChan stateVar = do
         return (False, snapshotWorkspaces previous)
   let nextRevision = snapshotRevision previous + 1
       next =
-        WorkspaceSnapshot
-          { snapshotBackend = WorkspaceBackendEWMH,
-            snapshotRevision = nextRevision,
-            snapshotWindowDataComplete = complete,
-            snapshotWorkspaces = workspaces
-          }
+        preserveWorkspaceUpdateRevisions previous $
+          WorkspaceSnapshot
+            { snapshotBackend = WorkspaceBackendEWMH,
+              snapshotRevision = nextRevision,
+              snapshotWindowDataComplete = complete,
+              snapshotWorkspaces = workspaces
+            }
       eventBatch =
         WorkspaceEventBatch
           { eventBatchBackend = WorkspaceBackendEWMH,
@@ -277,6 +280,7 @@ collectEWMHWorkspaceSnapshot = do
                   { workspaceNumericId = Just idx,
                     workspaceName = T.pack name
                   },
+              workspaceUpdateRevision = 0,
               workspaceState = wsViewState,
               workspaceHasUrgentWindow = any windowUrgent windowsInfo,
               workspaceIsSpecial = isSpecialWorkspaceName name,
@@ -310,6 +314,7 @@ getWindowInfo activeWindow urgentWindows window = do
   return
     WindowInfo
       { windowIdentity = X11WindowIdentity (fromIntegral window),
+        windowUpdateRevision = 0,
         windowTitle = T.pack wTitle,
         windowClassHints = map T.pack $ parseWindowClasses wClass,
         windowPosition = wPosition,

--- a/src/System/Taffybar/Information/Workspaces/Hyprland.hs
+++ b/src/System/Taffybar/Information/Workspaces/Hyprland.hs
@@ -58,6 +58,7 @@ import qualified System.Taffybar.Information.Hyprland as Hypr
 import qualified System.Taffybar.Information.Hyprland.API as HyprAPI
 import qualified System.Taffybar.Information.Hyprland.Types as HyprTypes
 import System.Taffybar.Information.Workspaces.Model
+import System.Taffybar.Information.Workspaces.Refresh (workspaceRefreshRequestLoop)
 
 data HyprlandWorkspaceProviderConfig = HyprlandWorkspaceProviderConfig
   { workspaceSnapshotGetter :: TaffyIO (Bool, [WorkspaceInfo]),
@@ -190,6 +191,7 @@ buildHyprlandWorkspaceStateChanVar cfg = do
   eventChan <- liftIO newBroadcastTChanIO
   var <- liftIO $ newMVar defaultHyprlandWorkspaceState
   taffyFork $ hyprlandWorkspaceStateLoop cfg stateChan eventChan var
+  taffyFork $ workspaceRefreshRequestLoop stateChan eventChan var
   return $ HyprlandWorkspaceStateChanVar (stateChan, eventChan, var)
 
 hyprlandWorkspaceStateLoop ::
@@ -235,12 +237,13 @@ refreshHyprlandWorkspaceState cfg stateChan workspaceEventChan var = do
           (specialWorkspaceWindowTarget cfg)
           rawWorkspaces
       next =
-        WorkspaceSnapshot
-          { snapshotBackend = WorkspaceBackendHyprland,
-            snapshotRevision = snapshotRevision previous + 1,
-            snapshotWindowDataComplete = complete,
-            snapshotWorkspaces = workspaces
-          }
+        preserveWorkspaceUpdateRevisions previous $
+          WorkspaceSnapshot
+            { snapshotBackend = WorkspaceBackendHyprland,
+              snapshotRevision = snapshotRevision previous + 1,
+              snapshotWindowDataComplete = complete,
+              snapshotWorkspaces = workspaces
+            }
       eventBatch =
         WorkspaceEventBatch
           { eventBatchBackend = snapshotBackend next,
@@ -318,6 +321,7 @@ buildHyprlandWorkspaceSnapshot = do
                     { workspaceNumericId = Just wsId,
                       workspaceName = wsName
                     },
+                workspaceUpdateRevision = 0,
                 workspaceState = wsState,
                 workspaceHasUrgentWindow = any windowUrgent wsWindows,
                 workspaceIsSpecial = isSpecialWorkspace wsId wsName,
@@ -423,6 +427,7 @@ applySpecialWorkspaceWindowTargets targetForWorkspace workspaces =
               { workspaceNumericId = Nothing,
                 workspaceName = targetName
               },
+          workspaceUpdateRevision = 0,
           workspaceState = WorkspaceEmpty,
           workspaceHasUrgentWindow = False,
           workspaceIsSpecial = True,
@@ -482,6 +487,7 @@ windowFromClient activeAddr client =
           || clientIsOnMinimizedWorkspace client
    in WindowInfo
         { windowIdentity = HyprlandWindowIdentity (HyprTypes.hyprClientAddress client),
+          windowUpdateRevision = 0,
           windowTitle = title,
           windowClassHints =
             catMaybes

--- a/src/System/Taffybar/Information/Workspaces/Model.hs
+++ b/src/System/Taffybar/Information/Workspaces/Model.hs
@@ -24,6 +24,9 @@ module System.Taffybar.Information.Workspaces.Model
     WorkspaceInfo (..),
     WindowIdentity (..),
     WindowInfo (..),
+    WorkspacesRefreshTarget (..),
+    bumpWorkspaceRefreshTarget,
+    preserveWorkspaceUpdateRevisions,
   )
 where
 
@@ -90,6 +93,7 @@ data WorkspaceIdentity = WorkspaceIdentity
 -- | Backend-neutral workspace information.
 data WorkspaceInfo = WorkspaceInfo
   { workspaceIdentity :: WorkspaceIdentity,
+    workspaceUpdateRevision :: Word64,
     workspaceState :: WorkspaceViewState,
     workspaceHasUrgentWindow :: Bool,
     workspaceIsSpecial :: Bool,
@@ -105,6 +109,7 @@ data WindowIdentity
 -- | Backend-neutral window information.
 data WindowInfo = WindowInfo
   { windowIdentity :: WindowIdentity,
+    windowUpdateRevision :: Word64,
     windowTitle :: Text,
     -- | Ordered class/app-id hints used for icon lookup.
     windowClassHints :: [Text],
@@ -116,6 +121,69 @@ data WindowInfo = WindowInfo
     windowPinned :: Bool
   }
   deriving (Eq, Show)
+
+data WorkspacesRefreshTarget
+  = RefreshAllWorkspaces
+  | RefreshWorkspace WorkspaceIdentity
+  | RefreshWindow WindowIdentity
+  deriving (Eq, Show)
+
+bumpWorkspaceRefreshTarget :: WorkspacesRefreshTarget -> WorkspaceSnapshot -> WorkspaceSnapshot
+bumpWorkspaceRefreshTarget target snapshot =
+  snapshot {snapshotWorkspaces = map bumpWorkspaceForTarget (snapshotWorkspaces snapshot)}
+  where
+    bumpWorkspaceRevision workspace =
+      workspace {workspaceUpdateRevision = workspaceUpdateRevision workspace + 1}
+    bumpWindowRevision window =
+      window {windowUpdateRevision = windowUpdateRevision window + 1}
+    bumpWorkspaceAndWindows workspace =
+      bumpWorkspaceRevision
+        workspace
+          { workspaceWindows = map bumpWindowRevision (workspaceWindows workspace)
+          }
+    bumpWindowForTarget targetWindow window
+      | windowIdentity window == targetWindow = bumpWindowRevision window
+      | otherwise = window
+    bumpWorkspaceForTarget workspace =
+      case target of
+        RefreshAllWorkspaces -> bumpWorkspaceAndWindows workspace
+        RefreshWorkspace targetWorkspace
+          | workspaceIdentity workspace == targetWorkspace -> bumpWorkspaceAndWindows workspace
+          | otherwise -> workspace
+        RefreshWindow targetWindow ->
+          workspace {workspaceWindows = map (bumpWindowForTarget targetWindow) (workspaceWindows workspace)}
+
+preserveWorkspaceUpdateRevisions :: WorkspaceSnapshot -> WorkspaceSnapshot -> WorkspaceSnapshot
+preserveWorkspaceUpdateRevisions previous next =
+  next {snapshotWorkspaces = map preserveWorkspaceRevision (snapshotWorkspaces next)}
+  where
+    previousWorkspaces =
+      M.fromList
+        [ (workspaceIdentity workspace, workspace)
+        | workspace <- snapshotWorkspaces previous
+        ]
+    previousWindows =
+      M.fromList
+        [ (windowIdentity window, window)
+        | workspace <- snapshotWorkspaces previous,
+          window <- workspaceWindows workspace
+        ]
+    preserveWindowRevision window =
+      case M.lookup (windowIdentity window) previousWindows of
+        Just previousWindow ->
+          window {windowUpdateRevision = windowUpdateRevision previousWindow}
+        Nothing -> window
+    preserveWorkspaceRevision workspace =
+      let withWindows =
+            workspace
+              { workspaceWindows = map preserveWindowRevision (workspaceWindows workspace)
+              }
+       in case M.lookup (workspaceIdentity workspace) previousWorkspaces of
+            Just previousWorkspace ->
+              withWindows
+                { workspaceUpdateRevision = workspaceUpdateRevision previousWorkspace
+                }
+            Nothing -> withWindows
 
 -- | Produce incremental events that describe the change from an old snapshot to
 -- a new one.

--- a/src/System/Taffybar/Information/Workspaces/Refresh.hs
+++ b/src/System/Taffybar/Information/Workspaces/Refresh.hs
@@ -1,0 +1,75 @@
+-- | Shared workspace refresh requests.
+module System.Taffybar.Information.Workspaces.Refresh
+  ( getWorkspacesRefreshRequestChan,
+    requestWorkspacesRefresh,
+    workspaceRefreshRequestLoop,
+  )
+where
+
+import Control.Concurrent.MVar (MVar, modifyMVar_)
+import Control.Concurrent.STM.TChan
+  ( TChan,
+    dupTChan,
+    newBroadcastTChanIO,
+    readTChan,
+    writeTChan,
+  )
+import Control.Monad (forever, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.STM (atomically)
+import System.Taffybar.Context (TaffyIO, getStateDefault)
+import System.Taffybar.Information.Workspaces.Model
+
+newtype WorkspacesRefreshRequestChan
+  = WorkspacesRefreshRequestChan (TChan WorkspacesRefreshTarget)
+
+getWorkspacesRefreshRequestChan :: TaffyIO (TChan WorkspacesRefreshTarget)
+getWorkspacesRefreshRequestChan = do
+  WorkspacesRefreshRequestChan chan <-
+    getStateDefault $
+      WorkspacesRefreshRequestChan <$> liftIO newBroadcastTChanIO
+  return chan
+
+requestWorkspacesRefresh :: WorkspacesRefreshTarget -> TaffyIO ()
+requestWorkspacesRefresh target = do
+  chan <- getWorkspacesRefreshRequestChan
+  liftIO $ atomically $ writeTChan chan target
+
+workspaceRefreshRequestLoop ::
+  TChan WorkspaceSnapshot ->
+  TChan WorkspaceEventBatch ->
+  MVar WorkspaceSnapshot ->
+  TaffyIO ()
+workspaceRefreshRequestLoop stateChan eventChan stateVar = do
+  requestChan <- getWorkspacesRefreshRequestChan
+  requests <- liftIO $ atomically $ dupTChan requestChan
+  forever $ do
+    target <- liftIO $ atomically $ readTChan requests
+    liftIO $ publishRefreshTarget stateChan eventChan stateVar target
+
+publishRefreshTarget ::
+  TChan WorkspaceSnapshot ->
+  TChan WorkspaceEventBatch ->
+  MVar WorkspaceSnapshot ->
+  WorkspacesRefreshTarget ->
+  IO ()
+publishRefreshTarget stateChan eventChan stateVar target =
+  modifyMVar_ stateVar $ \previous -> do
+    let refreshed = bumpWorkspaceRefreshTarget target previous
+        changed = snapshotWorkspaces refreshed /= snapshotWorkspaces previous
+        next =
+          refreshed
+            { snapshotRevision = snapshotRevision previous + 1
+            }
+        eventBatch =
+          WorkspaceEventBatch
+            { eventBatchBackend = snapshotBackend next,
+              eventBatchRevision = snapshotRevision next,
+              eventBatchWindowDataComplete = snapshotWindowDataComplete next,
+              eventBatchEvents = diffWorkspaceSnapshots previous next
+            }
+    when changed $
+      atomically $ do
+        writeTChan stateChan next
+        writeTChan eventChan eventBatch
+    return $ if changed then next else previous

--- a/src/System/Taffybar/Widget/Workspaces.hs
+++ b/src/System/Taffybar/Widget/Workspaces.hs
@@ -301,6 +301,9 @@ defaultWidgetBuilder cfg wsInfo = do
           if needsIconUpdate
             then updateWorkspaceIcons cfg wsRef iconsBox currentIcons newWs
             else return currentIcons
+        when forceIcons $
+          liftIO $
+            forM_ updatedIcons iconForceUpdate
         liftIO $ writeIORef iconsRef updatedIcons
         liftIO $ writeIORef lastWorkspaceRef newWs
       controller =
@@ -581,9 +584,9 @@ updateIconWidget iconWidget windowData = do
     stateClasses
     windowIconStatusClasses
 
-windowIconPixbufKey :: WindowInfo -> (WindowIdentity, [T.Text])
+windowIconPixbufKey :: WindowInfo -> (WindowIdentity, Word64, [T.Text], T.Text)
 windowIconPixbufKey windowInfo =
-  (windowIdentity windowInfo, windowClassHints windowInfo)
+  (windowIdentity windowInfo, windowUpdateRevision windowInfo, windowClassHints windowInfo, windowTitle windowInfo)
 
 windowIconStatusClasses :: [T.Text]
 windowIconStatusClasses = ["active", "urgent", "minimized", "normal", "inactive", "pinned"]

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -145,6 +145,7 @@ library
                  , System.Taffybar.Information.Bluetooth
                  , System.Taffybar.Information.CPU2
                  , System.Taffybar.Information.Chrome
+                 , System.Taffybar.Information.ChromeWindowInfo
                  , System.Taffybar.Information.Crypto
                  , System.Taffybar.Information.DiskIO
                  , System.Taffybar.Information.DiskUsage
@@ -169,6 +170,7 @@ library
                  , System.Taffybar.Information.Workspaces.EWMH
                  , System.Taffybar.Information.Workspaces.Hyprland
                  , System.Taffybar.Information.Workspaces.Model
+                 , System.Taffybar.Information.Workspaces.Refresh
                  , System.Taffybar.Information.Wakeup
                  , System.Taffybar.Information.Wlsunset
                  , System.Taffybar.Information.X11DesktopInfo

--- a/test/unit/System/Taffybar/Information/Workspaces/HyprlandSpec.hs
+++ b/test/unit/System/Taffybar/Information/Workspaces/HyprlandSpec.hs
@@ -13,6 +13,7 @@ mkWindow :: T.Text -> Bool -> WindowInfo
 mkWindow title minimized =
   WindowInfo
     { windowIdentity = HyprlandWindowIdentity title,
+      windowUpdateRevision = 0,
       windowTitle = title,
       windowClassHints = [],
       windowPosition = Nothing,
@@ -36,6 +37,7 @@ mkWorkspace idx name state special windows =
           { workspaceNumericId = idx,
             workspaceName = name
           },
+      workspaceUpdateRevision = 0,
       workspaceState = state,
       workspaceHasUrgentWindow = any windowUrgent windows,
       workspaceIsSpecial = special,

--- a/test/unit/System/Taffybar/Widget/Workspaces/ChannelSpec.hs
+++ b/test/unit/System/Taffybar/Widget/Workspaces/ChannelSpec.hs
@@ -10,6 +10,7 @@ mkX11Window :: Word64 -> Bool -> Maybe (Int, Int) -> WindowInfo
 mkX11Window wid minimized pos =
   WindowInfo
     { windowIdentity = X11WindowIdentity wid,
+      windowUpdateRevision = 0,
       windowTitle = T.pack (show wid),
       windowClassHints = [],
       windowPosition = pos,
@@ -27,6 +28,7 @@ mkWorkspace idx name state windows =
           { workspaceNumericId = Just idx,
             workspaceName = T.pack name
           },
+      workspaceUpdateRevision = 0,
       workspaceState = state,
       workspaceHasUrgentWindow = any windowUrgent windows,
       workspaceIsSpecial = False,
@@ -77,3 +79,27 @@ spec = do
                 [WindowAdded newW2, WindowChanged newW1]
             ]
       diffWorkspaceSnapshots oldSnap newSnap `shouldBe` expectedEvents
+
+    it "bumps update revisions for targeted window refreshes" $ do
+      let w1 = mkX11Window 1 False (Just (0, 0))
+          w2 = mkX11Window 2 False (Just (50, 50))
+          ws1 = mkWorkspace 1 "1" WorkspaceActive [w1, w2]
+          snap = mkSnapshot 10 [ws1]
+          refreshed = bumpWorkspaceRefreshTarget (RefreshWindow $ X11WindowIdentity 2) snap
+          refreshedRevisions =
+            concatMap
+              (map windowUpdateRevision . workspaceWindows)
+              (snapshotWorkspaces refreshed)
+      refreshedRevisions `shouldBe` [0, 1]
+
+    it "preserves update revisions across backend snapshots" $ do
+      let oldW1 = (mkX11Window 1 False (Just (0, 0))) {windowUpdateRevision = 3}
+          oldWs1 = (mkWorkspace 1 "1" WorkspaceActive [oldW1]) {workspaceUpdateRevision = 4}
+          previous = mkSnapshot 10 [oldWs1]
+          newW1 = (mkX11Window 1 False (Just (5, 5))) {windowUpdateRevision = 0}
+          newWs1 = (mkWorkspace 1 "1" WorkspaceHidden [newW1]) {workspaceUpdateRevision = 0}
+          next = preserveWorkspaceUpdateRevisions previous $ mkSnapshot 11 [newWs1]
+          preservedWorkspaces = snapshotWorkspaces next
+          preservedWindows = concatMap workspaceWindows preservedWorkspaces
+      map workspaceUpdateRevision preservedWorkspaces `shouldBe` [4]
+      map windowUpdateRevision preservedWindows `shouldBe` [3]


### PR DESCRIPTION
## Summary

- add workspace/window update revisions plus target-based workspace refresh requests
- have EWMH and Hyprland providers subscribe to a shared refresh request bus and publish ordinary workspace snapshots after forced refreshes
- keep workspace widgets on the existing snapshot channel instead of adding widget-level external refresh sources
- wire the Chrome window info D-Bus bridge to request targeted workspace refreshes

## Validation

- direnv exec . nix build --print-build-logs .#checks.x86_64-linux.ormolu .#checks.x86_64-linux.hlint
- direnv exec . cabal build lib:taffybar
- direnv exec . cabal test unit --test-options='--match Workspaces'

Full `direnv exec . cabal test unit` was also run; it failed on two environment-dependent existing tests: missing `taffybar-appearance-snap-hyprland` on PATH and backend detection returning Wayland where that test expected X11.
