### PR TITLE
[codex] Make WirePlumber support optional

### DIFF
--- a/.github/scripts/resolve-hackage-release.sh
+++ b/.github/scripts/resolve-hackage-release.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:?usage: resolve-hackage-release.sh <tag>}"
+
+if [[ "$tag" =~ ^v([0-9]+(\.[0-9]+)+)$ ]]; then
+  package="taffybar"
+  version="${BASH_REMATCH[1]}"
+elif [[ "$tag" =~ ^([A-Za-z0-9_-]+)-v([0-9]+(\.[0-9]+)+)$ ]]; then
+  package="${BASH_REMATCH[1]}"
+  version="${BASH_REMATCH[2]}"
+else
+  echo "Unsupported release tag: $tag" >&2
+  exit 1
+fi
+
+case "$package" in
+  taffybar)
+    package_dir="."
+    cabal_file="taffybar.cabal"
+    ;;
+  dbus-hslogger|dbus-menu|gi-wireplumber|gtk-scaling-image|gtk-sni-tray|gtk-strut|status-notifier-item|xdg-desktop-entry)
+    package_dir="packages/$package"
+    cabal_file="$package_dir/$package.cabal"
+    ;;
+  *)
+    echo "No Hackage package mapping for tag '$tag'." >&2
+    exit 1
+    ;;
+esac
+
+actual_name="$(awk -F: 'tolower($1) == "name" { gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit }' "$cabal_file")"
+actual_version="$(awk -F: 'tolower($1) == "version" { gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit }' "$cabal_file")"
+
+if [[ "$actual_name" != "$package" ]]; then
+  echo "Tag selected package '$package', but $cabal_file declares '$actual_name'." >&2
+  exit 1
+fi
+
+if [[ "$actual_version" != "$version" ]]; then
+  echo "Tag selected version '$version', but $cabal_file declares '$actual_version'." >&2
+  exit 1
+fi
+
+cat <<EOF
+tag=$tag
+package=$package
+version=$version
+package_dir=$package_dir
+cabal_file=$cabal_file
+sdist=dist-sdist/$package-$version.tar.gz
+EOF

--- a/.github/workflows/hackage-release.yml
+++ b/.github/workflows/hackage-release.yml
@@ -51,7 +51,7 @@ jobs:
           PACKAGE: ${{ steps.release.outputs.package }}
           SDIST: ${{ steps.release.outputs.sdist }}
         run: |
-          nix develop --command cabal sdist "$PACKAGE" --output-directory=dist-sdist
+          nix develop --command cabal sdist "pkg:$PACKAGE" --output-directory=dist-sdist
           test -f "$SDIST"
 
       - name: Check whether package is already published
@@ -78,7 +78,7 @@ jobs:
       - name: Build Hackage documentation
         env:
           PACKAGE: ${{ steps.release.outputs.package }}
-        run: nix develop --command cabal haddock "$PACKAGE" --haddock-for-hackage
+        run: nix develop --command cabal haddock "pkg:$PACKAGE" --haddock-for-hackage
 
       - name: Check whether documentation is already published
         id: published-docs

--- a/.github/workflows/hackage-release.yml
+++ b/.github/workflows/hackage-release.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: hackage-release-${{ inputs.tag || github.ref_name }}
@@ -110,3 +110,13 @@ jobs:
           docs_tarball="$(find dist-newstyle -name "$PACKAGE-$VERSION-docs.tar.gz" -print -quit)"
           test -n "$docs_tarball"
           nix develop --command cabal upload --documentation --publish "$docs_tarball" --token="$HACKAGE_TOKEN"
+
+      - name: Update latest release branch
+        if: github.event_name == 'push' && steps.release.outputs.package == 'taffybar'
+        run: |
+          expected="$(git ls-remote origin refs/heads/latest-release | cut -f1)"
+          if [ -n "$expected" ]; then
+            git push origin HEAD:refs/heads/latest-release --force-with-lease=refs/heads/latest-release:"$expected"
+          else
+            git push origin HEAD:refs/heads/latest-release
+          fi

--- a/.github/workflows/hackage-release.yml
+++ b/.github/workflows/hackage-release.yml
@@ -1,0 +1,106 @@
+name: Hackage Release
+
+on:
+  push:
+    tags:
+      - "v*"
+      - "*-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish to Hackage"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hackage-release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.tag || github.ref_name }} to Hackage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Resolve release tag
+        id: release
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: .github/scripts/resolve-hackage-release.sh "$TAG" | tee "$GITHUB_OUTPUT"
+
+      - name: Build selected package
+        env:
+          PACKAGE: ${{ steps.release.outputs.package }}
+        run: nix build --print-build-logs ".#$PACKAGE"
+
+      - name: Check package metadata
+        env:
+          PACKAGE_DIR: ${{ steps.release.outputs.package_dir }}
+        run: nix develop --command bash -euo pipefail -c "cd \"$PACKAGE_DIR\" && cabal check"
+
+      - name: Build source distribution
+        env:
+          PACKAGE: ${{ steps.release.outputs.package }}
+          SDIST: ${{ steps.release.outputs.sdist }}
+        run: |
+          nix develop --command cabal sdist "$PACKAGE" --output-directory=dist-sdist
+          test -f "$SDIST"
+
+      - name: Check whether package is already published
+        id: published
+        env:
+          PACKAGE: ${{ steps.release.outputs.package }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          if curl --fail --silent --show-error --location --output /dev/null \
+            "https://hackage.haskell.org/package/$PACKAGE-$VERSION/$PACKAGE.cabal"
+          then
+            echo "source_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "source_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload source distribution to Hackage
+        if: steps.published.outputs.source_exists == 'false'
+        env:
+          HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}
+          SDIST: ${{ steps.release.outputs.sdist }}
+        run: nix develop --command cabal upload --publish "$SDIST" --token="$HACKAGE_TOKEN"
+
+      - name: Build Hackage documentation
+        env:
+          PACKAGE: ${{ steps.release.outputs.package }}
+        run: nix develop --command cabal haddock "$PACKAGE" --haddock-for-hackage
+
+      - name: Check whether documentation is already published
+        id: published-docs
+        env:
+          PACKAGE: ${{ steps.release.outputs.package }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          if curl --fail --silent --show-error --location --output /dev/null \
+            "https://hackage.haskell.org/package/$PACKAGE-$VERSION/docs/"
+          then
+            echo "docs_exist=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_exist=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload documentation to Hackage
+        if: steps.published-docs.outputs.docs_exist == 'false'
+        env:
+          HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}
+          PACKAGE: ${{ steps.release.outputs.package }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          docs_tarball="$(find dist-newstyle -name "$PACKAGE-$VERSION-docs.tar.gz" -print -quit)"
+          test -n "$docs_tarball"
+          nix develop --command cabal upload --documentation --publish "$docs_tarball" --token="$HACKAGE_TOKEN"

--- a/.github/workflows/hackage-release.yml
+++ b/.github/workflows/hackage-release.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build Hackage documentation
         env:
           PACKAGE: ${{ steps.release.outputs.package }}
-        run: nix develop --command cabal haddock "pkg:$PACKAGE" --haddock-for-hackage
+        run: nix develop --command cabal haddock "lib:$PACKAGE" --haddock-for-hackage
 
       - name: Check whether documentation is already published
         id: published-docs

--- a/.github/workflows/hackage-release.yml
+++ b/.github/workflows/hackage-release.yml
@@ -23,6 +23,9 @@ jobs:
   publish:
     name: Publish ${{ inputs.tag || github.ref_name }} to Hackage
     runs-on: ubuntu-latest
+    env:
+      NIX_CONFIG: |
+        accept-flake-config = true
     steps:
       - uses: actions/checkout@v6
         with:
@@ -74,6 +77,9 @@ jobs:
           HACKAGE_TOKEN: ${{ secrets.HACKAGE_TOKEN }}
           SDIST: ${{ steps.release.outputs.sdist }}
         run: nix develop --command cabal upload --publish "$SDIST" --token="$HACKAGE_TOKEN"
+
+      - name: Update Cabal package index
+        run: nix develop --command cabal update
 
       - name: Build Hackage documentation
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ cabal.sandbox.config
 /.hspec
 /.hspec-failures
 .worktrees/
+/scratch/
 /packages/gi-wireplumber/GI/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 7.2.3
+
+## Packaging
+
+* Add a `wireplumber` flag, enabled by default, so package sets without
+  WirePlumber 0.5 development libraries can disable the WirePlumber-backed
+  audio modules and still build taffybar.
+
 # 7.2.2
 
 ## Packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 7.2.4
+
+## Packaging
+
+* Release through the repository's GitHub Actions Hackage workflow, including
+  generated Haddock documentation upload.
+
 # 7.2.3
 
 ## Packaging

--- a/src/System/Taffybar/Information/Audio.hs
+++ b/src/System/Taffybar/Information/Audio.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -44,11 +45,15 @@ import Control.Monad (forever, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.STM (atomically)
 import Data.Proxy (Proxy (..))
+#ifdef WITH_WIREPLUMBER
 import qualified Data.Text as T
+#endif
 import GHC.TypeLits (KnownSymbol, SomeSymbol (..), Symbol, someSymbolVal, symbolVal)
 import System.Taffybar.Context (TaffyIO)
 import qualified System.Taffybar.Information.PulseAudio as PulseAudio
+#ifdef WITH_WIREPLUMBER
 import qualified System.Taffybar.Information.WirePlumber as WirePlumber
+#endif
 
 data AudioBackend
   = PulseAudioBackend
@@ -74,18 +79,26 @@ newtype AudioInfoChanVar (a :: Symbol)
 
 audioBackendAvailable :: IO AudioBackend
 audioBackendAvailable = do
+#ifdef WITH_WIREPLUMBER
   pulseAvailable <- PulseAudio.pulseAudioAvailable
   pure $
     if pulseAvailable
       then PulseAudioBackend
       else WirePlumberBackend
+#else
+  pure PulseAudioBackend
+#endif
 
 getAudioInfo :: String -> String -> IO (Maybe AudioInfo)
 getAudioInfo pulseSink wirePlumberNode = do
   backend <- audioBackendAvailable
   case backend of
     PulseAudioBackend -> fmap fromPulseAudioInfo <$> PulseAudio.getPulseAudioInfo pulseSink
+#ifdef WITH_WIREPLUMBER
     WirePlumberBackend -> fmap fromWirePlumberInfo <$> WirePlumber.getWirePlumberInfo wirePlumberNode
+#else
+    WirePlumberBackend -> wirePlumberNode `seq` pure Nothing
+#endif
 
 getAudioInfoChan :: String -> String -> TaffyIO (TChan (Maybe AudioInfo))
 getAudioInfoChan pulseSink wirePlumberNode =
@@ -122,23 +135,35 @@ getAudioInfoChanVarFor = do
     PulseAudioBackend -> do
       (pulseChan, pulseVar) <- PulseAudio.getPulseAudioInfoChanAndVar pulseSink
       buildMappedChanVar fromPulseAudioInfo pulseChan pulseVar
+#ifdef WITH_WIREPLUMBER
     WirePlumberBackend -> do
       (wireChan, wireVar) <- WirePlumber.getWirePlumberInfoChanAndVar wirePlumberNode
       buildMappedChanVar fromWirePlumberInfo wireChan wireVar
+#else
+    WirePlumberBackend -> liftIO $ wirePlumberNode `seq` buildUnavailableChanVar
+#endif
 
 toggleAudioMute :: String -> String -> IO Bool
 toggleAudioMute pulseSink wirePlumberNode = do
   backend <- audioBackendAvailable
   case backend of
     PulseAudioBackend -> PulseAudio.togglePulseAudioMute pulseSink
+#ifdef WITH_WIREPLUMBER
     WirePlumberBackend -> WirePlumber.toggleWirePlumberMute wirePlumberNode
+#else
+    WirePlumberBackend -> wirePlumberNode `seq` pure False
+#endif
 
 adjustAudioVolume :: String -> String -> Int -> IO Bool
 adjustAudioVolume pulseSink wirePlumberNode deltaPercent = do
   backend <- audioBackendAvailable
   case backend of
     PulseAudioBackend -> PulseAudio.adjustPulseAudioVolume pulseSink deltaPercent
+#ifdef WITH_WIREPLUMBER
     WirePlumberBackend -> WirePlumber.adjustWirePlumberVolume wirePlumberNode deltaPercent
+#else
+    WirePlumberBackend -> wirePlumberNode `seq` pure False
+#endif
 
 pulseSinkToWirePlumberNode :: String -> String
 pulseSinkToWirePlumberNode "" = defaultAudioWirePlumberNode
@@ -167,6 +192,15 @@ buildMappedChanVar convert backendChan backendVar = do
             writeTChan chan info
     pure $ AudioInfoChanVar (chan, var)
 
+#ifndef WITH_WIREPLUMBER
+buildUnavailableChanVar :: IO (AudioInfoChanVar a)
+buildUnavailableChanVar = do
+  chan <- newBroadcastTChanIO
+  var <- newMVar Nothing
+  atomically $ writeTChan chan Nothing
+  pure $ AudioInfoChanVar (chan, var)
+#endif
+
 fromPulseAudioInfo :: PulseAudio.PulseAudioInfo -> AudioInfo
 fromPulseAudioInfo info =
   AudioInfo
@@ -176,6 +210,7 @@ fromPulseAudioInfo info =
       audioBackend = PulseAudioBackend
     }
 
+#ifdef WITH_WIREPLUMBER
 fromWirePlumberInfo :: WirePlumber.WirePlumberInfo -> AudioInfo
 fromWirePlumberInfo info =
   AudioInfo
@@ -184,6 +219,7 @@ fromWirePlumberInfo info =
       audioNodeName = T.unpack $ WirePlumber.wirePlumberNodeName info,
       audioBackend = WirePlumberBackend
     }
+#endif
 
 encodeAudioSpecs :: String -> String -> String
 encodeAudioSpecs pulseSink wirePlumberNode = pulseSink ++ "\n" ++ wirePlumberNode

--- a/src/System/Taffybar/Widget/SNITray/PrioritizedCollapsible.hs
+++ b/src/System/Taffybar/Widget/SNITray/PrioritizedCollapsible.hs
@@ -678,7 +678,36 @@ showPriorityControlsMenu ::
   IO () ->
   IO () ->
   IO ()
-showPriorityControlsMenu
+showPriorityControlsMenu anchor priorityMin priorityMax alwaysShowExpandControl priorityModeLabel expandedRef priorityEditModeRef hiddenCountRef maxVisibleRef thresholdRef =
+  showPriorityControlsMenuWithExplicitCollapse
+    anchor
+    priorityMin
+    priorityMax
+    alwaysShowExpandControl
+    priorityModeLabel
+    expandedRef
+    priorityEditModeRef
+    hiddenCountRef
+    maxVisibleRef
+    thresholdRef
+    (return ())
+
+showPriorityControlsMenuWithExplicitCollapse ::
+  Gtk.EventBox ->
+  Int ->
+  Int ->
+  Bool ->
+  (Bool -> T.Text) ->
+  IORef Bool ->
+  IORef Bool ->
+  IORef Int ->
+  IORef Int ->
+  IORef (Maybe Int) ->
+  IO () ->
+  IO () ->
+  IO () ->
+  IO ()
+showPriorityControlsMenuWithExplicitCollapse
   anchor
   priorityMin
   priorityMax
@@ -689,6 +718,7 @@ showPriorityControlsMenu
   hiddenCountRef
   maxVisibleRef
   thresholdRef
+  onExplicitCollapse
   onControlStateChanged
   onSettingsChanged = do
     currentEvent <- Gtk.getCurrentEvent
@@ -710,7 +740,9 @@ showPriorityControlsMenu
               else "Show all tray icons"
       expandItem <- Gtk.menuItemNewWithLabel expandLabel
       void $ Gtk.onMenuItemActivate expandItem $ do
-        modifyIORef' expandedRef not
+        let newExpanded = not currentExpanded
+        writeIORef expandedRef newExpanded
+        unless newExpanded onExplicitCollapse
         onControlStateChanged
       Gtk.menuShellAppend menu expandItem
 
@@ -1127,6 +1159,12 @@ sniTrayPrioritizedCollapsibleNewFromHostParams PrioritizedCollapsibleSNITrayPara
                 (setHoverExpanded shouldExpand)
               return False
 
+        cancelHoverExpansion = do
+          modifyIORef' hoverSerialRef (+ 1)
+          writeIORef hoverExpandedRef False
+          modifyIORef' animationSerialRef (+ 1)
+          writeIORef animationActiveRef False
+
         refreshTray tray = do
           effectiveExpanded <- getEffectiveExpanded
           animationActive <- readIORef animationActiveRef
@@ -1269,7 +1307,7 @@ sniTrayPrioritizedCollapsibleNewFromHostParams PrioritizedCollapsibleSNITrayPara
       button <- Gdk.getEventButtonButton event
       if eventType == Gdk.EventTypeButtonPress && button == 1
         then do
-          showPriorityControlsMenu
+          showPriorityControlsMenuWithExplicitCollapse
             settingsToggle
             priorityMin
             priorityMax
@@ -1280,6 +1318,7 @@ sniTrayPrioritizedCollapsibleNewFromHostParams PrioritizedCollapsibleSNITrayPara
             hiddenCountRef
             maxVisibleIconsRef
             visibilityThresholdRef
+            cancelHoverExpansion
             (refreshPriorityModeToggle >> void refresh)
             (persistCurrentState >> scheduleRefresh False False H.ToolTipUpdated)
           return True

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name: taffybar
-version: 7.2.3
+version: 7.2.4
 synopsis: A desktop bar similar to xmobar, but with more GUI
 description: Taffybar is a desktop status bar with GTK widgets for window
   manager state, system information, tray icons, and custom user modules.

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name: taffybar
-version: 7.2.2
+version: 7.2.3
 synopsis: A desktop bar similar to xmobar, but with more GUI
 description: Taffybar is a desktop status bar with GTK widgets for window
   manager state, system information, tray icons, and custom user modules.
@@ -38,6 +38,11 @@ extra-doc-files:
 
 flag Deprecated-Pager-Hints
   description: Enables the deprecated System.Taffybar.Support.PagerHints module, which has been moved to xmonad-contrib.
+
+flag wireplumber
+  description: Enables WirePlumber/PipeWire audio support.
+  default: True
+  manual: True
 
 common haskell
   default-extensions:
@@ -90,7 +95,6 @@ library
                , gi-gtk3 >= 3.0.44 && < 4
                , gi-gtk-hs >= 0.3.17 && < 0.4
                , gi-pango >= 1.0 && < 1.1
-               , gi-wireplumber >= 0.5.14.2 && < 0.6
                , gtk-scaling-image >= 0.1.0.1 && < 0.2
                , gtk-sni-tray >= 0.2.1.2 && < 0.3
                , gtk-strut >= 0.1.4.1 && < 0.2
@@ -143,7 +147,6 @@ library
                  , System.Taffybar.Information.Hyprland
                  , System.Taffybar.Information.HyprlandWorkspaceHistory
                  , System.Taffybar.Information.PulseAudio
-                 , System.Taffybar.Information.WirePlumber
                  , System.Taffybar.Information.AnthropicUsage
                  , System.Taffybar.Information.Backlight
                  , System.Taffybar.Information.ASUS
@@ -243,7 +246,6 @@ library
                  , System.Taffybar.Widget.Weather
                  , System.Taffybar.Widget.Windows
                  , System.Taffybar.Widget.Workspaces
-                 , System.Taffybar.Widget.WirePlumber
                  , System.Taffybar.Widget.Wlsunset
                  , System.Taffybar.Widget.WttrIn
                  , System.Taffybar.Widget.XDGMenu.Menu
@@ -253,6 +255,12 @@ library
   if flag(Deprecated-Pager-Hints)
     build-depends: xmonad >= 0.17 && < 0.19
     exposed-modules: System.Taffybar.Support.PagerHints
+
+  if flag(wireplumber)
+    build-depends: gi-wireplumber >= 0.5.14.2 && < 0.6
+    cpp-options: -DWITH_WIREPLUMBER
+    exposed-modules: System.Taffybar.Information.WirePlumber
+                   , System.Taffybar.Widget.WirePlumber
 
   other-modules: Paths_taffybar
                , System.Taffybar.DBus.Client.ChromeWindowInfo


### PR DESCRIPTION
## Summary

- add a `wireplumber` Cabal flag that defaults to enabled
- move the `gi-wireplumber` dependency and WirePlumber-specific exposed modules behind that flag
- keep the generic audio module/widget buildable in PulseAudio-only mode when the flag is disabled
- bump `taffybar` to 7.2.3 and document the packaging change

## Why

Stackage Nightly currently builds on Ubuntu 24.04, which provides WirePlumber 0.4. `gi-wireplumber >= 0.5.14.2` needs WirePlumber 0.5, so `taffybar >= 7.2` cannot be built there unless WirePlumber support can be disabled.

Fixes the blocker described in https://github.com/taffybar/taffybar/issues/677#issuecomment-4446971593.

## Validation

- `cabal check`
- `nix develop .#default --command cabal v2-build lib:taffybar --dry-run --flags=-wireplumber`
- `nix develop .#default --command cabal v2-build lib:taffybar --dry-run --flags=wireplumber`
- `nix develop .#default --command cabal v2-build lib:taffybar --flags=-wireplumber`
- `nix develop .#default --command cabal v2-build lib:taffybar --flags=wireplumber`