### PR TITLE
Add priority-based dynamic widget hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Features
 
+* Add `System.Taffybar.WidgetPriority`, which supports priority-based dynamic
+  hiding of bar widgets when the bar runs out of horizontal space. Wrapping a
+  widget constructor with `withPriority` (re-exported from
+  `System.Taffybar.SimpleConfig`) marks it as hideable; when the natural
+  widths of the bar's widgets exceed the available width, prioritized widgets
+  are hidden lowest-priority-first and shown again (with a hysteresis margin)
+  when space frees up. Widgets without a priority are never hidden, and bars
+  with no prioritized widgets behave exactly as before. Hidden widgets get the
+  `priority-hidden` CSS class.
+
 * The Anthropic usage widget now reports rate-limit utilization percentages
   and reset times from the OAuth usage endpoint that Claude Code itself polls,
   authenticated with the access token from Claude Code's local credentials

--- a/src/System/Taffybar/Context.hs
+++ b/src/System/Taffybar/Context.hs
@@ -143,6 +143,7 @@ import System.Taffybar.Information.Wakeup.Manager
 import System.Taffybar.Information.X11DesktopInfo
 import System.Taffybar.Util
 import System.Taffybar.Widget.Util
+import System.Taffybar.WidgetPriority (defaultDynamicHidingConfig, setupDynamicHiding)
 import System.Taffybar.Window.FocusedMonitor
   ( FocusedMonitorHooks (..),
     setupFocusedMonitorClassUpdates,
@@ -746,20 +747,29 @@ buildBarWindow context barConfig = do
             addToStart count widget = do
               _ <- addIndexedClass "left" count widget
               Gtk.boxPackStart box widget False False 0
+              return widget
             addToEnd count widget = do
               _ <- addIndexedClass "right" count widget
               _ <- addEndPaletteClasses count widget
               Gtk.boxPackEnd box widget False False 0
+              return widget
             addToCenter count widget = do
               _ <- addIndexedClass "center" count widget
               Gtk.boxPackStart centerBox widget False False 0
+              return widget
 
         logIO DEBUG "Building start widgets"
-        mapM_ (addWidgetWith addToStart) $ zip [1 ..] (startWidgets barConfig)
+        builtStart <- mapM (addWidgetWith addToStart) $ zip [1 ..] (startWidgets barConfig)
         logIO DEBUG "Building center widgets"
-        mapM_ (addWidgetWith addToCenter) $ zip [1 ..] (centerWidgets barConfig)
+        builtCenter <- mapM (addWidgetWith addToCenter) $ zip [1 ..] (centerWidgets barConfig)
         logIO DEBUG "Building end widgets"
-        mapM_ (addWidgetWith addToEnd) $ zip [1 ..] (endWidgets barConfig)
+        builtEnd <- mapM (addWidgetWith addToEnd) $ zip [1 ..] (endWidgets barConfig)
+
+        setupDynamicHiding
+          defaultDynamicHidingConfig
+          (widgetSpacing barConfig)
+          box
+          (builtStart ++ builtCenter ++ builtEnd)
 
         return [box, centerBox]
       Just levels -> do
@@ -802,20 +812,29 @@ buildBarWindow context barConfig = do
                   addToStart count widget = do
                     _ <- addIndexedClass "left" count widget
                     Gtk.boxPackStart box widget False False 0
+                    return widget
                   addToEnd count widget = do
                     _ <- addIndexedClass "right" count widget
                     _ <- addEndPaletteClasses count widget
                     Gtk.boxPackEnd box widget False False 0
+                    return widget
                   addToCenter count widget = do
                     _ <- addIndexedClass "center" count widget
                     Gtk.boxPackStart centerBox widget False False 0
+                    return widget
 
               logIO DEBUG $ printf "Building level %d start widgets" (levelCount :: Int)
-              mapM_ (addWidgetWith addToStart) $ zip [1 ..] starts
+              builtStart <- mapM (addWidgetWith addToStart) $ zip [1 ..] starts
               logIO DEBUG $ printf "Building level %d center widgets" (levelCount :: Int)
-              mapM_ (addWidgetWith addToCenter) $ zip [1 ..] centers
+              builtCenter <- mapM (addWidgetWith addToCenter) $ zip [1 ..] centers
               logIO DEBUG $ printf "Building level %d end widgets" (levelCount :: Int)
-              mapM_ (addWidgetWith addToEnd) $ zip [1 ..] ends
+              builtEnd <- mapM (addWidgetWith addToEnd) $ zip [1 ..] ends
+
+              setupDynamicHiding
+                defaultDynamicHidingConfig
+                (widgetSpacing barConfig)
+                box
+                (builtStart ++ builtCenter ++ builtEnd)
 
               return (box, centerBox)
 

--- a/src/System/Taffybar/SimpleConfig.hs
+++ b/src/System/Taffybar/SimpleConfig.hs
@@ -27,6 +27,8 @@ module System.Taffybar.SimpleConfig
     toTaffybarConfig,
     useAllMonitors,
     usePrimaryMonitor,
+    withPriority,
+    setWidgetPriority,
     StrutSize,
     pattern ExactSize,
     pattern ScreenRatio,
@@ -48,6 +50,7 @@ import System.Taffybar
 import System.Taffybar.Context hiding (BarConfig (..), TaffybarConfig (..))
 import qualified System.Taffybar.Context as BC (BarConfig (..), TaffybarConfig (..))
 import System.Taffybar.Util
+import System.Taffybar.WidgetPriority (setWidgetPriority, withPriority)
 
 -- | Size of a bar strut reservation. This is an alias for
 -- 'Graphics.UI.GIGtkStrut.StrutSize'.

--- a/src/System/Taffybar/WidgetPriority.hs
+++ b/src/System/Taffybar/WidgetPriority.hs
@@ -1,0 +1,269 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+
+-- |
+-- Module      : System.Taffybar.WidgetPriority
+-- Copyright   : (c) Ivan A. Malison
+-- License     : BSD3-style (see LICENSE)
+--
+-- Maintainer  : Ivan A. Malison
+-- Stability   : unstable
+-- Portability : unportable
+--
+-- Priority-based dynamic hiding of bar widgets when the bar runs out of
+-- horizontal space.
+--
+-- Wrap any widget constructor with 'withPriority' to make it hideable:
+--
+-- > endWidgets = [clock, withPriority 10 battery, withPriority 3 weather]
+--
+-- Widgets without a priority are never hidden. When the natural widths of
+-- all widgets exceed the width allocated to the bar, prioritized widgets
+-- are hidden lowest-priority-first until everything fits. Hidden widgets
+-- are shown again when enough space (plus a small hysteresis margin)
+-- becomes available. The mechanism is entirely opt-in: bars that contain
+-- no prioritized widgets get no visibility controller at all.
+module System.Taffybar.WidgetPriority
+  ( -- * Assigning priorities
+    withPriority,
+    setWidgetPriority,
+    getWidgetPriority,
+
+    -- * Hiding configuration
+    DynamicHidingConfig (..),
+    defaultDynamicHidingConfig,
+
+    -- * Bar wiring (used by "System.Taffybar.Context")
+    setupDynamicHiding,
+  )
+where
+
+import Control.Monad (filterM, forM, forM_, unless, void, when)
+import Control.Monad.IO.Class (MonadIO)
+import Data.Default (Default (..))
+import Data.IORef
+import Data.Int (Int32)
+import Data.List (sortOn)
+import Data.Maybe (isJust)
+import Data.Ord (Down (..))
+import qualified Data.Text as T
+import Foreign.Ptr (Ptr, intPtrToPtr, ptrToIntPtr)
+import qualified GI.GLib as GLib
+import qualified GI.GObject as GObject
+import qualified GI.Gtk as Gtk
+import System.Log.Logger (Priority (DEBUG), logM)
+import Text.Printf (printf)
+
+priorityLog :: Priority -> String -> IO ()
+priorityLog = logM "System.Taffybar.WidgetPriority"
+
+-- | GObject data key under which a widget's priority is stored.
+priorityDataKey :: T.Text
+priorityDataKey = "taffy-widget-priority"
+
+-- | GObject data key marking widgets that were hidden by the visibility
+-- controller (as opposed to widgets that hid themselves).
+hiddenByControllerKey :: T.Text
+hiddenByControllerKey = "taffy-priority-hidden"
+
+-- Priorities are smuggled through g_object_set_data's @Ptr ()@ payload.
+-- 0 (the null pointer) means "no priority set", so non-negative priorities
+-- are stored shifted up by one.
+encodePriority :: Int -> Ptr ()
+encodePriority p = intPtrToPtr $ fromIntegral $ if p >= 0 then p + 1 else p
+
+decodePriority :: Ptr () -> Maybe Int
+decodePriority ptr =
+  case fromIntegral (ptrToIntPtr ptr) :: Int of
+    0 -> Nothing
+    v
+      | v > 0 -> Just (v - 1)
+      | otherwise -> Just v
+
+-- | Annotate an already-built widget with a hiding priority. The annotation
+-- mechanism works on any 'GObject.Object', though the bar only consults it on
+-- top-level section widgets.
+setWidgetPriority :: (MonadIO m, GObject.IsObject o) => Int -> o -> m ()
+setWidgetPriority p widget = do
+  object <- GObject.toObject widget
+  GObject.objectSetData object priorityDataKey (encodePriority p)
+
+-- | Read back a priority set with 'setWidgetPriority' or 'withPriority'.
+getWidgetPriority :: (MonadIO m, GObject.IsObject o) => o -> m (Maybe Int)
+getWidgetPriority widget = do
+  object <- GObject.toObject widget
+  decodePriority <$> GObject.objectGetData object priorityDataKey
+
+-- | Give a hiding priority to the widget produced by the given constructor.
+-- Lower priorities are hidden first when the bar runs out of space; widgets
+-- built without 'withPriority' are never hidden. This combinator does not
+-- change the constructor's type, so prioritized and raw widgets mix freely
+-- in the same widget list. Apply it as the outermost wrapper, after any
+-- combinators that rebuild the widget inside a new container.
+withPriority :: (MonadIO m) => Int -> m Gtk.Widget -> m Gtk.Widget
+withPriority p buildWidget = do
+  widget <- buildWidget
+  setWidgetPriority p widget
+  return widget
+
+setHiddenByController :: (MonadIO m, GObject.IsObject o) => Bool -> o -> m ()
+setHiddenByController flag widget = do
+  object <- GObject.toObject widget
+  GObject.objectSetData object hiddenByControllerKey $
+    intPtrToPtr (if flag then 1 else 0)
+
+getHiddenByController :: (MonadIO m, GObject.IsObject o) => o -> m Bool
+getHiddenByController widget = do
+  object <- GObject.toObject widget
+  (/= 0) . ptrToIntPtr <$> GObject.objectGetData object hiddenByControllerKey
+
+-- | Configuration for the dynamic hiding controller.
+data DynamicHidingConfig = DynamicHidingConfig
+  { -- | Extra pixels that must be available before a hidden widget is shown
+    -- again. This hysteresis margin prevents widgets from flapping between
+    -- hidden and shown when the bar is right at the edge of fitting.
+    reshowSlackPx :: Int32,
+    -- | CSS class added to widgets while they are hidden by the controller.
+    hiddenCssClass :: T.Text,
+    -- | How often (in milliseconds) to re-evaluate visibility even without a
+    -- size-allocation event. Hidden widgets do not trigger relayout when
+    -- their natural size changes, so without this they could stay hidden
+    -- after shrinking enough to fit. 'Nothing' disables the periodic check.
+    recheckIntervalMs :: Maybe Word
+  }
+
+-- | 'DynamicHidingConfig' with a 20px reshow margin and a 1s periodic check.
+defaultDynamicHidingConfig :: DynamicHidingConfig
+defaultDynamicHidingConfig =
+  DynamicHidingConfig
+    { reshowSlackPx = 20,
+      hiddenCssClass = "priority-hidden",
+      recheckIntervalMs = Just 1000
+    }
+
+instance Default DynamicHidingConfig where
+  def = defaultDynamicHidingConfig
+
+-- | Install a visibility controller on a bar box. The widget list should
+-- contain the box's top-level section widgets in visual order. Does nothing
+-- when no widget in the list carries a priority, so it is safe to call
+-- unconditionally.
+setupDynamicHiding ::
+  DynamicHidingConfig -> Int32 -> Gtk.Box -> [Gtk.Widget] -> IO ()
+setupDynamicHiding config spacing box widgets = do
+  anyPrioritized <- not . null <$> filterM (fmap isJust . getWidgetPriority) widgets
+  when anyPrioritized $ do
+    priorityLog DEBUG $
+      printf "Enabling dynamic widget hiding for a bar with %d widgets" (length widgets)
+    destroyedRef <- newIORef False
+    recheckPendingRef <- newIORef False
+
+    let recompute = do
+          destroyed <- readIORef destroyedRef
+          unless destroyed $ applyVisibilityPass config spacing box widgets
+
+        scheduleRecompute = do
+          pending <- atomicModifyIORef' recheckPendingRef (True,)
+          unless pending $
+            void $
+              GLib.idleAdd GLib.PRIORITY_DEFAULT_IDLE $ do
+                writeIORef recheckPendingRef False
+                recompute
+                return False
+
+    void $ Gtk.onWidgetSizeAllocate box $ const scheduleRecompute
+    scheduleRecompute
+
+    timeoutId <- forM (recheckIntervalMs config) $ \intervalMs ->
+      GLib.timeoutAdd GLib.PRIORITY_DEFAULT_IDLE (fromIntegral intervalMs) $ do
+        recompute
+        return True
+
+    void $ Gtk.onWidgetDestroy box $ do
+      writeIORef destroyedRef True
+      forM_ timeoutId GLib.sourceRemove
+
+data WidgetInfo = WidgetInfo
+  { wiWidget :: Gtk.Widget,
+    wiPriority :: Maybe Int,
+    wiVisible :: Bool,
+    wiHiddenByUs :: Bool,
+    wiNaturalWidth :: Int32
+  }
+
+-- | A widget is under the controller's authority when it has a priority and
+-- is either visible or was hidden by the controller itself. Prioritized
+-- widgets that hid themselves are left alone until they reappear.
+wiManaged :: WidgetInfo -> Bool
+wiManaged info =
+  isJust (wiPriority info) && (wiVisible info || wiHiddenByUs info)
+
+applyVisibilityPass ::
+  DynamicHidingConfig -> Int32 -> Gtk.Box -> [Gtk.Widget] -> IO ()
+applyVisibilityPass config spacing box widgets = do
+  available <- Gtk.widgetGetAllocatedWidth box
+  when (available > 1) $ do
+    infos <- forM widgets $ \widget -> do
+      priority <- getWidgetPriority widget
+      visible <- Gtk.widgetGetVisible widget
+      hiddenByUs <- getHiddenByController widget
+      natural <- snd <$> Gtk.widgetGetPreferredWidth widget
+      return
+        WidgetInfo
+          { wiWidget = widget,
+            wiPriority = priority,
+            wiVisible = visible,
+            wiHiddenByUs = hiddenByUs,
+            wiNaturalWidth = natural
+          }
+
+    let (managed, unmanaged) = (filter wiManaged infos, filter (not . wiManaged) infos)
+        unmanagedVisible = filter wiVisible unmanaged
+        -- Every visible widget is charged one unit of box spacing. This
+        -- slightly overestimates the gaps GTK actually inserts, which only
+        -- errs toward hiding a touch early.
+        widthWithGap info = wiNaturalWidth info + spacing
+        baseline = sum (map widthWithGap unmanagedVisible)
+
+        -- Strict priority order: walk from highest priority down and cut
+        -- off at the first widget that does not fit. sortOn is stable, so
+        -- widgets with equal priority keep their visual order.
+        ordered = sortOn (Down . wiPriority) managed
+
+        decide _ [] = []
+        decide used (info : rest)
+          | required <= available =
+              (info, True) : decide (used + widthWithGap info) rest
+          | otherwise = map (,False) (info : rest)
+          where
+            slack = if wiVisible info then 0 else reshowSlackPx config
+            required = used + widthWithGap info + slack
+
+        decisions = decide baseline ordered
+
+    forM_ decisions $ \(info, shouldShow) ->
+      when (wiVisible info /= shouldShow) $ do
+        let widget = wiWidget info
+        styleContext <- Gtk.widgetGetStyleContext widget
+        if shouldShow
+          then do
+            priorityLog DEBUG $
+              printf "Showing widget with priority %s" (show $ wiPriority info)
+            setHiddenByController False widget
+            Gtk.widgetSetNoShowAll widget False
+            Gtk.styleContextRemoveClass styleContext (hiddenCssClass config)
+            Gtk.widgetShow widget
+          else do
+            priorityLog DEBUG $
+              printf "Hiding widget with priority %s" (show $ wiPriority info)
+            setHiddenByController True widget
+            -- Some widgets refresh themselves with widgetShowAll on a
+            -- parent container; no-show-all keeps those refreshes from
+            -- undoing the controller's decision.
+            Gtk.widgetSetNoShowAll widget True
+            Gtk.styleContextAddClass styleContext (hiddenCssClass config)
+            Gtk.widgetHide widget

--- a/taffybar.cabal
+++ b/taffybar.cabal
@@ -186,6 +186,7 @@ library
                  , System.Taffybar.LogLevels
                  , System.Taffybar.SimpleConfig
                  , System.Taffybar.Util
+                 , System.Taffybar.WidgetPriority
                  , System.Taffybar.Widget
                  , System.Taffybar.Widget.Audio
                  , System.Taffybar.Widget.PulseAudio
@@ -401,6 +402,7 @@ test-suite unit
                , System.Taffybar.Information.X11DesktopInfoSpec
                , System.Taffybar.Information.WakeupSpec
                , System.Taffybar.SimpleConfigSpec
+               , System.Taffybar.WidgetPrioritySpec
                , System.Taffybar.Widget.SNITray.PrioritizedCollapsibleSpec
                , System.Taffybar.Widget.Workspaces.ChannelSpec
                , System.Taffybar.Widget.WindowsSpec

--- a/test/unit/System/Taffybar/WidgetPrioritySpec.hs
+++ b/test/unit/System/Taffybar/WidgetPrioritySpec.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module System.Taffybar.WidgetPrioritySpec (spec) where
+
+import GI.Gtk qualified as Gtk
+import System.Taffybar.WidgetPriority
+import Test.Hspec
+
+-- GtkAdjustment is a plain GObject with no display dependency, so the
+-- annotation round-trip can be tested without initializing GTK. The bar
+-- applies the same mechanism to widgets.
+newTestObject :: IO Gtk.Adjustment
+newTestObject = Gtk.adjustmentNew 0 0 100 1 10 10
+
+spec :: Spec
+spec =
+  describe "widget priority annotations" $ do
+    it "round-trips priorities, including zero and negative values" $ do
+      object <- newTestObject
+      getWidgetPriority object `shouldReturn` Nothing
+      setWidgetPriority 5 object
+      getWidgetPriority object `shouldReturn` Just 5
+      setWidgetPriority 0 object
+      getWidgetPriority object `shouldReturn` Just 0
+      setWidgetPriority (-3) object
+      getWidgetPriority object `shouldReturn` Just (-3)
+
+    it "keeps annotations on separate objects independent" $ do
+      annotated <- newTestObject
+      plain <- newTestObject
+      setWidgetPriority 7 annotated
+      getWidgetPriority annotated `shouldReturn` Just 7
+      getWidgetPriority plain `shouldReturn` Nothing


### PR DESCRIPTION
## Summary

Adds `System.Taffybar.WidgetPriority`: when the natural widths of a bar's widgets exceed the width allocated to the bar, prioritized widgets are hidden lowest-priority-first until everything fits, and shown again (with a hysteresis margin) when space frees up.

```haskell
endWidgets = [clock, withPriority 10 battery, withPriority 3 weather]
```

### Design

* **Fully backward compatible.** `withPriority :: MonadIO m => Int -> m Gtk.Widget -> m Gtk.Widget` keeps the constructor type, so prioritized and plain widgets mix freely in the same list and no config record fields change. The priority travels as GObject data on the built widget. Bars with no prioritized widgets get no visibility controller at all.
* **Bar-level controller.** `buildBarWindow` collects the built section widgets and installs a controller on each bar box (including per level in multi-level bars). It recomputes on `size-allocate`, debounced through an idle callback, plus a periodic recheck to catch hidden widgets whose natural size shrinks (they trigger no relayout while unmapped).
* **Deterministic decisions.** Natural widths are measured for all managed widgets — including currently hidden ones — so each pass computes the visible set in one shot, walking priorities highest-first with a strict cutoff. Re-showing requires configurable slack (default 20px) to prevent flapping at the boundary.
* **Robustness.** Hidden widgets get `gtk_widget_set_no_show_all` so widget-internal `show_all` refreshes can't undo a hide, plus a `priority-hidden` CSS class. Prioritized widgets that hide *themselves* are left alone until they reappear.

`withPriority` and `setWidgetPriority` are re-exported from `System.Taffybar.SimpleConfig`.

## Testing

* Unit spec for the annotation round-trip (including zero/negative priorities), display-free.
* Verified end-to-end with a live bar under Xvfb: a bar whose widgets total ~1000px on an 800px screen hides exactly the lowest-priority widget while plain widgets stay; on a 1400px screen everything stays visible.
* The full `imalison-taffybar` configuration compiles unchanged against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)